### PR TITLE
Do not set "dismissed" status in broker-db

### DIFF
--- a/cads_broker/database.py
+++ b/cads_broker/database.py
@@ -482,7 +482,6 @@ def delete_request(
     request = get_request(request_uid, session)
     session.delete(request)
     session.commit()
-    request.status = "dismissed"
     return request
 
 

--- a/cads_broker/database.py
+++ b/cads_broker/database.py
@@ -479,10 +479,10 @@ def delete_request(
     request_uid: str,
     session: sa.orm.Session,
 ) -> SystemRequest:
-    set_request_status(request_uid=request_uid, status="dismissed", session=session)
     request = get_request(request_uid, session)
     session.delete(request)
     session.commit()
+    request.status = "dismissed"
     return request
 
 


### PR DESCRIPTION
This PR remove setting of "dismissed" status in the broker-db before job cancellation.