### PR TITLE
Remove pydantic dependency

### DIFF
--- a/cads_broker/database.py
+++ b/cads_broker/database.py
@@ -516,9 +516,9 @@ def init_database(connection_string: str, force: bool = False) -> sa.engine.Engi
         query = sa.text(
             "SELECT table_name FROM information_schema.tables WHERE table_schema='public'"
         )
-        conn = engine.connect()
-        if "system_requests" not in conn.execute(query).scalars().all():
-            force = True
+        with engine.connect() as conn:
+            if "system_requests" not in conn.execute(query).scalars().all():
+                force = True
     if force:
         # cleanup and create the schema
         BaseModel.metadata.drop_all(engine)

--- a/environment.yml
+++ b/environment.yml
@@ -18,7 +18,6 @@ dependencies:
 - postgresql
 - psycopg
 - psycopg2
-- pydantic<2
 - sqlalchemy>=2.0.9
 - sqlalchemy-utils
 - structlog

--- a/tests/test_01_config.py
+++ b/tests/test_01_config.py
@@ -25,6 +25,21 @@ def test_sqlalchemysettings(temp_environ: Any) -> None:
     assert settings.compute_db_password == "a password"
     config.dbsettings = None
 
+    # take also other values from the environment
+    temp_environ["compute_db_password"] = "1"
+    temp_environ["compute_db_user"] = "2"
+    temp_environ["compute_db_host"] = "3"
+    temp_environ["compute_db_name"] = "4"
+    temp_environ["pool_timeout"] = "5.0"
+    temp_environ["pool_recycle"] = "6"
+    settings = config.SqlalchemySettings()
+    assert settings.compute_db_password == "1"
+    assert settings.compute_db_user == "2"
+    assert settings.compute_db_host == "3"
+    assert settings.compute_db_name == "4"
+    assert settings.pool_timeout == 5.0
+    assert settings.pool_recycle == 6
+
 
 def test_ensure_settings(session_obj: sa.orm.sessionmaker, temp_environ: Any) -> None:
     temp_environ["compute_db_password"] = "apassword"


### PR DESCRIPTION
Implementation of config.SqlalchemySettings without pydantic, using python's builtin dataclasses (like cads-catalogue).