### PR TITLE
Dynamic qos rules values

### DIFF
--- a/cads_broker/database.py
+++ b/cads_broker/database.py
@@ -307,13 +307,15 @@ def count_users(status: str, entry_point: str, session: sa.orm.Session) -> int:
     )
 
 
-def get_qos_status_from_request(request: dict[str, Any]) -> dict[str, list[str]]:
+def get_qos_status_from_request(
+    request: dict[str, Any]
+) -> dict[str, list[tuple[str, str]]]:
     ret_value: dict[str, list[str]] = {}
     for rule_name, rules in request["qos_status"].items():
         ret_value[rule_name] = []
         for rule in rules.values():
             ret_value[rule_name].append(
-                [rule.get("info", ""), rule.get("conclusion", "")]
+                (rule.get("info", ""), rule.get("conclusion", ""))
             )
     return ret_value
 

--- a/cads_broker/database.py
+++ b/cads_broker/database.py
@@ -312,7 +312,9 @@ def get_qos_status_from_request(request: dict[str, Any]) -> dict[str, list[str]]
     for rule_name, rules in request["qos_status"].items():
         ret_value[rule_name] = []
         for rule in rules.values():
-            ret_value[rule_name].append(rule.get("info", ""))
+            ret_value[rule_name].append(
+                [rule.get("info", ""), rule.get("conclusion", "")]
+            )
     return ret_value
 
 
@@ -328,7 +330,7 @@ def set_request_qos_rule(
         return
     old_rules[rule_uid] = {
         "conclusion": str(rule.evaluate(request)),
-        "info": str(rule.info),
+        "info": str(rule.info).replace('"', ""),
         "condition": str(rule.condition),
     }
     qos_status[rule.name] = old_rules

--- a/cads_broker/qos/QoS.py
+++ b/cads_broker/qos/QoS.py
@@ -100,8 +100,8 @@ class QoS:
         for i, limit in enumerate(properties.limits):
             if limit.full(request):
                 # performance. avoid interacting with db if limit is already there
-                if limit.uid not in request.qos_status.get(limit.name, []):
-                    database.set_request_qos_rule(request.request_uid, limit, session)
+                if limit.get_uid(request) not in request.qos_status.get(limit.name, []):
+                    database.set_request_qos_rule(request, limit, session)
                 limits.append(limit)
         session.commit()
         permissions = []

--- a/cads_broker/qos/Rule.py
+++ b/cads_broker/qos/Rule.py
@@ -45,9 +45,8 @@ class QoSRule:
     def dump(self, out):
         out(self)
 
-    @property
-    def uid(self):
-        return str(hash(self.__repr__()))
+    def get_uid(self, request):
+        return str(hash(f"{self.name} {self.info} {self.condition} : {self.evaluate(request)}"))
 
     def __repr__(self):
         return f"{self.name} {self.info} {self.condition} : {self.conclusion}"

--- a/tests/test_02_database.py
+++ b/tests/test_02_database.py
@@ -20,7 +20,12 @@ class MockRule:
         self.conclusion = conclusion
         self.info = info
         self.condition = condition
+    
+    def get_uid(self, request):
+        return self.uid
 
+    def evaluate(self, request):
+        return self.uid
 
 def mock_config(hash: str = "", config: dict[str, Any] = {}, form: dict[str, Any] = {}):
     adaptor_properties = db.AdaptorProperties(
@@ -505,8 +510,8 @@ def test_set_request_qos_rule(session_obj: sa.orm.sessionmaker) -> None:
         session.add(adaptor_properties)
         session.add(request)
         session.commit()
-        db.set_request_qos_rule(request_uid=request_uid, rule=limit_1, session=session)
-        db.set_request_qos_rule(request_uid=request_uid, rule=limit_2, session=session)
+        db.set_request_qos_rule(request=request, rule=limit_1, session=session)
+        db.set_request_qos_rule(request=request, rule=limit_2, session=session)
         session.commit()
     with session_obj() as session:
         request = db.get_request(request_uid=request_uid, session=session)

--- a/tests/test_02_database.py
+++ b/tests/test_02_database.py
@@ -532,7 +532,10 @@ def test_get_qos_status_from_request() -> None:
             "rule_name_2": {"rule_key_2_1": {}},
         }
     }
-    exp_qos_status = {"rule_name_1": ["info_1_1", "info_1_2"], "rule_name_2": [""]}
+    exp_qos_status = {
+        "rule_name_1": [["info_1_1", "conclusion_1_1"], ["info_1_2", "conclusion_1_2"]],
+        "rule_name_2": [["", ""]],
+    }
     res_qos_staus = db.get_qos_status_from_request(test_request)
     assert exp_qos_status == res_qos_staus
 

--- a/tests/test_02_database.py
+++ b/tests/test_02_database.py
@@ -20,12 +20,13 @@ class MockRule:
         self.conclusion = conclusion
         self.info = info
         self.condition = condition
-    
+
     def get_uid(self, request):
         return self.uid
 
     def evaluate(self, request):
         return self.uid
+
 
 def mock_config(hash: str = "", config: dict[str, Any] = {}, form: dict[str, Any] = {}):
     adaptor_properties = db.AdaptorProperties(
@@ -538,8 +539,8 @@ def test_get_qos_status_from_request() -> None:
         }
     }
     exp_qos_status = {
-        "rule_name_1": [["info_1_1", "conclusion_1_1"], ["info_1_2", "conclusion_1_2"]],
-        "rule_name_2": [["", ""]],
+        "rule_name_1": [("info_1_1", "conclusion_1_1"), ("info_1_2", "conclusion_1_2")],
+        "rule_name_2": [("", "")],
     }
     res_qos_staus = db.get_qos_status_from_request(test_request)
     assert exp_qos_status == res_qos_staus


### PR DESCRIPTION
This PR implements the following features:
- set a numeric value for rules "conclusion";
- update `database.get_qos_status_from_request` to also return rules "conclusion"