### PR TITLE
Update get_qos_status_from_request

### DIFF
--- a/cads_broker/config.py
+++ b/cads_broker/config.py
@@ -51,13 +51,12 @@ class SqlalchemySettings(pydantic_settings.BaseSettings):
     def password_must_be_set(
         cls: pydantic_settings.BaseSettings,
         v: str | None,
-        info: pydantic_core.core_schema.FieldValidationInfo,
+        info: pydantic_core.core_schema.ValidationInfo,
     ) -> str | None:
         """Check that password is explicitly set."""
         if v is None:
             raise ValueError(f"{info.field_name} must be set")
         return v
-
 
     @property
     def connection_string(self) -> str:

--- a/cads_broker/database.py
+++ b/cads_broker/database.py
@@ -83,7 +83,7 @@ class SystemRequest(BaseModel):
 
     # joined is temporary
     cache_entry = sa.orm.relationship(cacholote.database.CacheEntry, lazy="joined")
-    adaptor_properties = sa.orm.relationship(AdaptorProperties, lazy="joined")
+    adaptor_properties = sa.orm.relationship(AdaptorProperties, lazy="select")
 
     @property
     def age(self):

--- a/cads_broker/database.py
+++ b/cads_broker/database.py
@@ -307,9 +307,9 @@ def count_users(status: str, entry_point: str, session: sa.orm.Session) -> int:
     )
 
 
-def get_qos_status_from_request(request: dict[str, Any]) -> dict[str, list[str]]:
+def get_qos_status_from_request(request: SystemRequest) -> dict[str, list[str]]:
     ret_value: dict[str, list[str]] = {}
-    for rule_name, rules in request["qos_status"].items():
+    for rule_name, rules in request.qos_status.items():
         ret_value[rule_name] = []
         for rule in rules.values():
             ret_value[rule_name].append(rule.get("info", ""))

--- a/tests/test_02_database.py
+++ b/tests/test_02_database.py
@@ -521,7 +521,7 @@ def test_set_request_qos_rule(session_obj: sa.orm.sessionmaker) -> None:
 
 
 def test_get_qos_status_from_request() -> None:
-    test_request = {
+    test_qos_status = {
         "qos_status": {
             "rule_name_1": {
                 "rule_key_1_1": {
@@ -538,6 +538,7 @@ def test_get_qos_status_from_request() -> None:
             "rule_name_2": {"rule_key_2_1": {}},
         }
     }
+    test_request = db.SystemRequest(**test_qos_status)
     exp_qos_status = {
         "rule_name_1": [("info_1_1", "conclusion_1_1"), ("info_1_2", "conclusion_1_2")],
         "rule_name_2": [("", "")],


### PR DESCRIPTION
This PR:
- updates `get_qos_status_from_request`, now accepting a `cads_broker.SystemRequest` instead of a `dict` as a parameter;
- solves a deprecation warning in `config.py`

Blocks:
- https://github.com/ecmwf-projects/cads-processing-api-service/pull/156