### PR TITLE
Make pool parameters configurable

### DIFF
--- a/cads_broker/config.py
+++ b/cads_broker/config.py
@@ -40,6 +40,8 @@ class SqlalchemySettings(pydantic_settings.BaseSettings):
     compute_db_name: str | None = None
     pool_timeout: float = 1.0
     pool_recycle: int = 60
+    pool_size: int = 10
+    max_overflow: int = 15
 
     @pydantic.field_validator(
         "compute_db_user",


### PR DESCRIPTION
This PR:
- makes `pool_size` and `max_overflow` parameters configurable

Blocks:
- https://github.com/ecmwf-projects/cads-processing-api-service/pull/161