### PR TITLE
added some indexes on system_requests table

### DIFF
--- a/alembic/versions/6460fbf5a6d5_index_on_cache_id.py
+++ b/alembic/versions/6460fbf5a6d5_index_on_cache_id.py
@@ -19,7 +19,15 @@ def upgrade() -> None:
     alembic.op.create_index(
         "idx_system_requests_cache_id", "system_requests", ["cache_id"]
     )
+    alembic.op.create_index(
+        "idx_system_requests_process_id", "system_requests", ["process_id"]
+    )
+    alembic.op.create_index(
+        "idx_system_requests_user_uid", "system_requests", ["user_uid"]
+    )
 
 
 def downgrade() -> None:
     alembic.op.drop_index("idx_system_requests_cache_id")
+    alembic.op.drop_index("idx_system_requests_process_id")
+    alembic.op.drop_index("idx_system_requests_user_uid")

--- a/alembic/versions/6460fbf5a6d5_index_on_cache_id.py
+++ b/alembic/versions/6460fbf5a6d5_index_on_cache_id.py
@@ -1,0 +1,25 @@
+"""index on cache_id.
+
+Revision ID: 6460fbf5a6d5
+Revises: 01374a5b3c41
+Create Date: 2023-11-24 14:04:45.930916
+
+"""
+
+import alembic
+
+# revision identifiers, used by Alembic.
+revision = "6460fbf5a6d5"
+down_revision = "01374a5b3c41"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    alembic.op.create_index(
+        "idx_system_requests_cache_id", "system_requests", ["cache_id"]
+    )
+
+
+def downgrade() -> None:
+    alembic.op.drop_index("idx_system_requests_cache_id")

--- a/cads_broker/database.py
+++ b/cads_broker/database.py
@@ -55,7 +55,7 @@ class SystemRequest(BaseModel):
     process_id = sa.Column(sa.Text)
     user_uid = sa.Column(sa.Text)
     status = sa.Column(status_enum)
-    cache_id = sa.Column(sa.Integer)
+    cache_id = sa.Column(sa.Integer, index=True)
     request_body = sa.Column(JSONB, nullable=False)
     request_metadata = sa.Column(JSONB)
     response_error = sa.Column(JSONB, default={})

--- a/cads_broker/database.py
+++ b/cads_broker/database.py
@@ -52,8 +52,8 @@ class SystemRequest(BaseModel):
         index=True,
         unique=True,
     )
-    process_id = sa.Column(sa.Text)
-    user_uid = sa.Column(sa.Text)
+    process_id = sa.Column(sa.Text, index=True)
+    user_uid = sa.Column(sa.Text, index=True)
     status = sa.Column(status_enum)
     cache_id = sa.Column(sa.Integer, index=True)
     request_body = sa.Column(JSONB, nullable=False)


### PR DESCRIPTION
It was added some indexes on the table system_requests of the broker database as a result of duration of integration tests using up to 2 milions of records in the table.

- cache_id: this heavily improves performances of cache cleaner
- process_id and user_id: without these indexes, performance of API get_jobs degrades rapidly as the number of records grows

These new indexes worsen write performance and database size, so load tests have been repeated comparing benefits and worsening: the results of the load tests (with a small set of records, about 140K) is that overall performance is not appreciably changed.
