### PR TITLE
Enable human-readable exception message by Processing API

### DIFF
--- a/cads_broker/database.py
+++ b/cads_broker/database.py
@@ -7,6 +7,7 @@ import uuid
 from typing import Any
 
 import cacholote
+import psycopg2.errors
 import sqlalchemy as sa
 import sqlalchemy.orm.exc
 import sqlalchemy_utils
@@ -28,6 +29,10 @@ status_enum = sa.Enum(
 
 
 class NoResultFound(Exception):
+    pass
+
+
+class InvalidRequestID(Exception):
     pass
 
 
@@ -544,6 +549,8 @@ def get_request(
             SystemRequest.request_uid == request_uid
         )
         return session.scalars(statement).one()
+    except psycopg2.errors.InvalidTextRepresentation:
+        raise InvalidRequestID(f"Invalid request_uid {request_uid}")
     except sqlalchemy.orm.exc.NoResultFound:
         logger.exception("get_request failed")
         raise NoResultFound(f"No request found with request_uid {request_uid}")

--- a/cads_broker/database.py
+++ b/cads_broker/database.py
@@ -7,8 +7,8 @@ import uuid
 from typing import Any
 
 import cacholote
-import psycopg2.errors
 import sqlalchemy as sa
+import sqlalchemy.exc
 import sqlalchemy.orm.exc
 import sqlalchemy_utils
 import structlog
@@ -549,7 +549,7 @@ def get_request(
             SystemRequest.request_uid == request_uid
         )
         return session.scalars(statement).one()
-    except psycopg2.errors.InvalidTextRepresentation:
+    except sqlalchemy.exc.DataError:
         raise InvalidRequestID(f"Invalid request_uid {request_uid}")
     except sqlalchemy.orm.exc.NoResultFound:
         logger.exception("get_request failed")


### PR DESCRIPTION
This PR introduces an ad-hoc exception which is raised when an invalid request uid (not `uuid4`) is asked for. In this way, the `retrieve-api` can return an error message specifying the reason of the failure.

**Needed by**
- https://github.com/ecmwf-projects/cads-processing-api-service/pull/170