### PR TITLE
[WIP] Create events table for live logs and worker name

### DIFF
--- a/alembic/versions/8924bc485ad5_add_events_table.py
+++ b/alembic/versions/8924bc485ad5_add_events_table.py
@@ -1,17 +1,17 @@
-"""Add events table
+"""Add events table.
 
 Revision ID: 8924bc485ad5
 Revises: 6460fbf5a6d5
 Create Date: 2024-01-26 14:43:44.421999
 
 """
-from alembic import op
 import sqlalchemy as sa
 
+from alembic import op
 
 # revision identifiers, used by Alembic.
-revision = '8924bc485ad5'
-down_revision = '6460fbf5a6d5'
+revision = "8924bc485ad5"
+down_revision = "6460fbf5a6d5"
 branch_labels = None
 depends_on = None
 
@@ -30,6 +30,7 @@ def upgrade() -> None:
             index=True,
         ),
     )
+
 
 def downgrade() -> None:
     op.drop_table("events")

--- a/alembic/versions/8924bc485ad5_add_events_table.py
+++ b/alembic/versions/8924bc485ad5_add_events_table.py
@@ -1,0 +1,35 @@
+"""Add events table
+
+Revision ID: 8924bc485ad5
+Revises: 6460fbf5a6d5
+Create Date: 2024-01-26 14:43:44.421999
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '8924bc485ad5'
+down_revision = '6460fbf5a6d5'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "events",
+        sa.Column("event_id", sa.Integer, primary_key=True),
+        sa.Column("event_type", ),
+        sa.Column("message", sa.Text),
+        sa.Column("timestamp", sa.TIMESTAMP, default=sa.func.now()),
+        sa.Column(
+            "request_uid",
+            sa.dialects.postgresql.UUID(False),
+            sa.ForeignKey("system_requests.request_uid"),
+            index=True,
+        ),
+    )
+
+def downgrade() -> None:
+    op.drop_table("events")

--- a/alembic/versions/8924bc485ad5_add_events_table.py
+++ b/alembic/versions/8924bc485ad5_add_events_table.py
@@ -20,7 +20,7 @@ def upgrade() -> None:
     op.create_table(
         "events",
         sa.Column("event_id", sa.Integer, primary_key=True),
-        sa.Column("event_type", sa.Text),
+        sa.Column("event_type", sa.Text, index=True),
         sa.Column("message", sa.Text),
         sa.Column("timestamp", sa.TIMESTAMP, default=sa.func.now()),
         sa.Column(

--- a/alembic/versions/8924bc485ad5_add_events_table.py
+++ b/alembic/versions/8924bc485ad5_add_events_table.py
@@ -20,7 +20,7 @@ def upgrade() -> None:
     op.create_table(
         "events",
         sa.Column("event_id", sa.Integer, primary_key=True),
-        sa.Column("event_type", ),
+        sa.Column("event_type", sa.Text),
         sa.Column("message", sa.Text),
         sa.Column("timestamp", sa.TIMESTAMP, default=sa.func.now()),
         sa.Column(

--- a/cads_broker/database.py
+++ b/cads_broker/database.py
@@ -38,19 +38,19 @@ class InvalidRequestID(Exception):
 
 class Events(BaseModel):
     """Events ORM model."""
-    
+
     __tablename__ = "events"
 
     event_id = sa.Column(sa.Integer, primary_key=True)
     event_type = sa.Column(sa.Text, index=True)
     request_uid = sa.Column(
         sa.dialects.postgresql.UUID(False),
-        sa.ForeignKey('system_requests.request_uid'),
+        sa.ForeignKey("system_requests.request_uid"),
         index=True,
     )
     message = sa.Column(sa.Text)
     timestamp = sa.Column(sa.TIMESTAMP, default=sa.func.now())
-    
+
 
 class AdaptorProperties(BaseModel):
     """Adaptor Metadata ORM model."""
@@ -461,7 +461,11 @@ def logger_kwargs(request: SystemRequest) -> dict[str, str]:
         "user_request": True,
         "process_id": request.process_id,
         "resubmit_number": request.request_metadata.get("resubmit_number", 0),
-        "worker_name": [event.message for event in request.events if event.event_type == "worker_name"],
+        "worker_name": [
+            event.message
+            for event in request.events
+            if event.event_type == "worker_name"
+        ],
         "origin": request.origin,
         "entry_point": request.entry_point,
         **request.response_error,

--- a/cads_broker/database.py
+++ b/cads_broker/database.py
@@ -42,7 +42,7 @@ class Events(BaseModel):
     __tablename__ = "events"
 
     event_id = sa.Column(sa.Integer, primary_key=True)
-    event_type = sa.Column(sa.Text)
+    event_type = sa.Column(sa.Text, index=True)
     request_uid = sa.Column(
         sa.dialects.postgresql.UUID(False),
         sa.ForeignKey('system_requests.request_uid'),

--- a/tests/test_02_database.py
+++ b/tests/test_02_database.py
@@ -669,7 +669,7 @@ def test_add_event(session_obj: sa.orm.sessionmaker) -> None:
             db.SystemRequest.request_uid == request_uid_1
         )
         request = session.scalars(statement).one()
-    
+
         assert request.events[0].event_type == "event_1"
         assert request.events[0].message == "message_1"
         assert request.events[1].message == "message_11"

--- a/tests/test_02_database.py
+++ b/tests/test_02_database.py
@@ -45,6 +45,7 @@ def mock_system_request(
     user_uid: str | None = None,
     cache_id: int | None = None,
     request_body: dict | None = None,
+    request_metadata: dict | None = None,
     adaptor_properties_hash: str = "adaptor_properties_hash",
     entry_point: str = "entry_point",
 ) -> db.SystemRequest:
@@ -57,6 +58,7 @@ def mock_system_request(
         started_at=None,
         cache_id=cache_id,
         request_body=request_body or {"request_type": "test"},
+        request_metadata=request_metadata or {},
         adaptor_properties_hash=adaptor_properties_hash,
         entry_point=entry_point,
     )
@@ -638,6 +640,41 @@ def test_set_request_status(session_obj: sa.orm.sessionmaker) -> None:
     assert failed_request.response_error["message"] == error_message
     assert failed_request.cache_id is None
     assert failed_request.finished_at is not None
+
+
+def test_add_event(session_obj: sa.orm.sessionmaker) -> None:
+    adaptor_properties = mock_config()
+    request_1 = mock_system_request(
+        status="accepted", adaptor_properties_hash=adaptor_properties.hash
+    )
+    request_2 = mock_system_request(
+        status="accepted", adaptor_properties_hash=adaptor_properties.hash
+    )
+    request_uid_1 = request_1.request_uid
+    request_uid_2 = request_2.request_uid
+
+    # running status
+    with session_obj() as session:
+        session.add(adaptor_properties)
+        session.add(request_1)
+        session.add(request_2)
+        session.commit()
+
+        db.add_event("event_1", request_uid_1, "message_1", session=session)
+        db.add_event("event_1", request_uid_1, "message_11", session=session)
+        db.add_event("event_2", request_uid_2, "message_2", session=session)
+
+    with session_obj() as session:
+        statement = sa.select(db.SystemRequest).where(
+            db.SystemRequest.request_uid == request_uid_1
+        )
+        request = session.scalars(statement).one()
+    
+        assert request.events[0].event_type == "event_1"
+        assert request.events[0].message == "message_1"
+        assert request.events[1].message == "message_11"
+        with pytest.raises(IndexError):
+            request.events[2].message
 
 
 def test_create_request(session_obj: sa.orm.sessionmaker) -> None:


### PR DESCRIPTION
This PR adds `events` table to the broker database to store events related to a `request`. The table has 5 columns:
- `event_id`: id of the event
- `event_type`: type of the event. For example `worker_name`, `user_visible_log`, `log` etc...
- `request_uid`: the request uid of the request, this is a foreign key to `system_request.request_uid`.
- `message`: the content of the event.
- `timestamp`: creation timestamp of the event.

Pros and cons for the worker name info (see [this PR](https://github.com/ecmwf-projects/cads-broker/pull/97)).
Pros:
- the broker code workflow remains unchanged

Cons:
- the information of the worker is outside the `system_request` table and is harder to access by this [line](https://github.com/ecmwf-projects/cads-broker/pull/96/files#diff-4465685761e79266040a6277adba1f639fcd217d9059ef91109182c92c2adf9fR464)

This PR has to be merged with https://github.com/ecmwf-projects/cads-worker/pull/32. 