### PR TITLE
[WIP] Add worker name metadata

### DIFF
--- a/cads_broker/database.py
+++ b/cads_broker/database.py
@@ -386,6 +386,21 @@ def requeue_request(
         return
 
 
+def set_request_worker_name(
+    request_uid: str,
+    worker_name: dict[str: Any],
+    session: sa.orm.Session,
+) -> SystemRequest:
+    """Set the status of a request."""
+    statement = sa.select(SystemRequest).where(SystemRequest.request_uid == request_uid)
+    request = session.scalars(statement).one()
+    metadata = dict(request.request_metadata)
+    metadata.update({"worker_name": worker_name})
+    request.request_metadata = metadata
+    session.commit()
+    return request
+
+
 def set_request_status(
     request_uid: str,
     status: str,
@@ -444,6 +459,7 @@ def logger_kwargs(request: SystemRequest) -> dict[str, str]:
         "user_request": True,
         "process_id": request.process_id,
         "resubmit_number": request.request_metadata.get("resubmit_number", 0),
+        "worker_name": request.request_metadata.get("worker_name"),
         "origin": request.origin,
         "entry_point": request.entry_point,
         **request.response_error,

--- a/cads_broker/dispatcher.py
+++ b/cads_broker/dispatcher.py
@@ -198,7 +198,8 @@ class Broker:
                 logger.info(
                     "Request not found: re-queueing", job_id={request.request_uid}
                 )
-                db.requeue_request(request_uid=request.request_uid, session=session)
+                with self.lock:
+                    db.requeue_request(request_uid=request.request_uid, session=session)
 
     def on_future_done(self, future: distributed.Future) -> None:
         job_status = DASK_STATUS_TO_STATUS.get(future.status, "accepted")

--- a/cads_broker/dispatcher.py
+++ b/cads_broker/dispatcher.py
@@ -150,9 +150,9 @@ class Broker:
         self.environment.number_of_workers = number_of_workers
         return number_of_workers
 
-    # @cachetools.cachedmethod(  # type: ignore
-    #     cache=operator.attrgetter("cache"),
-    # )
+    @cachetools.cachedmethod(  # type: ignore
+        cache=operator.attrgetter("cache"),
+    )
     def sync_database(self, session: sa.orm.Session) -> None:
         """Sync the database with the current status of the dask tasks.
 

--- a/cads_broker/dispatcher.py
+++ b/cads_broker/dispatcher.py
@@ -150,9 +150,9 @@ class Broker:
         self.environment.number_of_workers = number_of_workers
         return number_of_workers
 
-    @cachetools.cachedmethod(  # type: ignore
-        cache=operator.attrgetter("cache"),
-    )
+    # @cachetools.cachedmethod(  # type: ignore
+    #     cache=operator.attrgetter("cache"),
+    # )
     def sync_database(self, session: sa.orm.Session) -> None:
         """Sync the database with the current status of the dask tasks.
 


### PR DESCRIPTION
This PR adds the information on where (on which worker) a request is running.
This implementation is an alternative to this one: https://github.com/ecmwf-projects/cads-broker/pull/96.

Pros:
- the information of the worker is inside the `system_request` table and is easily accessible by this [line](https://github.com/ecmwf-projects/cads-broker/pull/97/files#diff-4465685761e79266040a6277adba1f639fcd217d9059ef91109182c92c2adf9fR462)

Cons:
- The broker has to write the worker name info when the request is submitted to the worker. This doubles the number of [database writes](https://github.com/ecmwf-projects/cads-broker/pull/97/files#diff-e191a5ebb9d3e8ececfea5011f2830b47349d41d7df626091f561522e22c0a16R179) from the broker. 

This PR has to be merged with https://github.com/ecmwf-projects/cads-worker/pull/33.