### PR TITLE
COPDS-1489: remove old requests

### DIFF
--- a/alembic/versions/6ee20703d353_cascading_delete_on_events.py
+++ b/alembic/versions/6ee20703d353_cascading_delete_on_events.py
@@ -1,0 +1,31 @@
+"""cascading delete on events
+
+Revision ID: 6ee20703d353
+Revises: 8924bc485ad5
+Create Date: 2024-03-28 12:07:05.247016
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '6ee20703d353'
+down_revision = '8924bc485ad5'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_constraint('events_request_uid_fkey', 'events')
+    op.create_foreign_key(
+        "events_request_uid_fkey", "events", "system_requests",
+        ["request_uid"], ["request_uid"], ondelete="CASCADE"
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint('events_request_uid_fkey', 'events')
+    op.create_foreign_key(
+        "events_request_uid_fkey", "events", "system_requests",
+        ["request_uid"], ["request_uid"],
+    )

--- a/alembic/versions/6ee20703d353_cascading_delete_on_events.py
+++ b/alembic/versions/6ee20703d353_cascading_delete_on_events.py
@@ -1,31 +1,57 @@
-"""cascading delete on events
+"""cascading delete on events.
 
 Revision ID: 6ee20703d353
 Revises: 8924bc485ad5
 Create Date: 2024-03-28 12:07:05.247016
 
 """
+import datetime
+
+import sqlalchemy as sa
+
 from alembic import op
 
-
 # revision identifiers, used by Alembic.
-revision = '6ee20703d353'
-down_revision = '8924bc485ad5'
+revision = "6ee20703d353"
+down_revision = "8924bc485ad5"
 branch_labels = None
 depends_on = None
 
 
 def upgrade() -> None:
-    op.drop_constraint('events_request_uid_fkey', 'events')
+    op.drop_column("system_requests", "request_id")
+    op.create_primary_key("system_requests_pkey", "system_requests", ["request_uid"])
+    op.drop_constraint("events_request_uid_fkey", "events")
+    op.drop_index("ix_system_requests_request_uid", "system_requests_pkey")
     op.create_foreign_key(
-        "events_request_uid_fkey", "events", "system_requests",
-        ["request_uid"], ["request_uid"], ondelete="CASCADE"
+        "events_request_uid_fkey",
+        "events",
+        "system_requests",
+        ["request_uid"],
+        ["request_uid"],
+        ondelete="CASCADE",
+    )
+    op.add_column(
+        "adaptor_properties",
+        sa.Column("timestamp", sa.TIMESTAMP, default=sa.func.now()),
+    )
+    now_str = datetime.datetime.now().isoformat()
+    op.execute(
+        f"update adaptor_properties set timestamp='{now_str}' where timestamp is null"
     )
 
 
 def downgrade() -> None:
-    op.drop_constraint('events_request_uid_fkey', 'events')
+    # do only on empty table
+    op.drop_constraint("events_request_uid_fkey", "events")
+    op.drop_constraint("system_requests_pkey", "system_requests")
+    op.add_column(
+        "system_requests", sa.Column("request_id", sa.Integer, primary_key=True)
+    )
     op.create_foreign_key(
-        "events_request_uid_fkey", "events", "system_requests",
-        ["request_uid"], ["request_uid"],
+        "events_request_uid_fkey",
+        "events",
+        "system_requests",
+        ["request_uid"],
+        ["request_uid"],
     )

--- a/cads_broker/database.py
+++ b/cads_broker/database.py
@@ -46,7 +46,7 @@ class Events(BaseModel):
     event_type = sa.Column(sa.Text, index=True)
     request_uid = sa.Column(
         sa.dialects.postgresql.UUID(False),
-        sa.ForeignKey("system_requests.request_uid"),
+        sa.ForeignKey("system_requests.request_uid", ondelete="CASCADE"),
         index=True,
     )
     message = sa.Column(sa.Text)
@@ -106,7 +106,7 @@ class SystemRequest(BaseModel):
     # joined is temporary
     cache_entry = sa.orm.relationship(cacholote.database.CacheEntry, lazy="joined")
     adaptor_properties = sa.orm.relationship(AdaptorProperties, lazy="select")
-    events = sa.orm.relationship(Events, lazy="select")
+    events = sa.orm.relationship(Events, lazy="select", passive_deletes=True)
 
     @property
     def age(self):

--- a/cads_broker/database.py
+++ b/cads_broker/database.py
@@ -61,6 +61,7 @@ class AdaptorProperties(BaseModel):
     hash = sa.Column(sa.Text, primary_key=True)
     config = sa.Column(JSONB)
     form = sa.Column(JSONB)
+    timestamp = sa.Column(sa.TIMESTAMP, default=sa.func.now())
 
 
 class SystemRequest(BaseModel):
@@ -68,12 +69,7 @@ class SystemRequest(BaseModel):
 
     __tablename__ = "system_requests"
 
-    request_id = sa.Column(sa.Integer, primary_key=True)
-    request_uid = sa.Column(
-        sa.dialects.postgresql.UUID(False),
-        index=True,
-        unique=True,
-    )
+    request_uid = sa.Column(sa.dialects.postgresql.UUID(False), primary_key=True)
     process_id = sa.Column(sa.Text, index=True)
     user_uid = sa.Column(sa.Text, index=True)
     status = sa.Column(status_enum)
@@ -102,6 +98,8 @@ class SystemRequest(BaseModel):
         ),
         {},
     )
+    # https://github.com/sqlalchemy/sqlalchemy/issues/11063#issuecomment-2008101926
+    __mapper_args__ = {"eager_defaults": False}
 
     # joined is temporary
     cache_entry = sa.orm.relationship(cacholote.database.CacheEntry, lazy="joined")

--- a/cads_broker/database.py
+++ b/cads_broker/database.py
@@ -670,6 +670,7 @@ def init_database(connection_string: str, force: bool = False) -> sa.engine.Engi
         conn = engine.connect()
         if "system_requests" not in conn.execute(query).scalars().all():
             force = True
+        conn.close()
     if force:
         # cleanup and create the schema
         BaseModel.metadata.drop_all(engine)

--- a/cads_broker/entry_points.py
+++ b/cads_broker/entry_points.py
@@ -12,7 +12,7 @@ app = typer.Typer()
 
 
 @app.command()
-def remove_old_records(
+def remove_old_requests(
     connection_string: Optional[str] = None, older_than_days: Optional[int] = 365
 ) -> None:
     """Remove records from the system_requests table older than `older_than_days`.

--- a/tests/test_20_dispatcher.py
+++ b/tests/test_20_dispatcher.py
@@ -1,5 +1,4 @@
 import datetime
-import random
 import uuid
 from typing import Any
 
@@ -32,7 +31,6 @@ def mock_system_request(
     adaptor_properties_hash: str = "adaptor_properties_hash",
 ) -> db.SystemRequest:
     system_request = db.SystemRequest(
-        request_id=random.randrange(1, 100),
         request_uid=request_uid or str(uuid.uuid4()),
         status=status,
         created_at=created_at,

--- a/tests/test_90_entry_points.py
+++ b/tests/test_90_entry_points.py
@@ -121,7 +121,7 @@ def test_remove_old_records(session_obj: sa.orm.sessionmaker):
     # remove nothing, older_than_days=365 by default, and oldest is 360
     result = runner.invoke(
         entry_points.app,
-        ["remove-old-records", "--connection-string", connection_string],
+        ["remove-old-requests", "--connection-string", connection_string],
     )
     assert result.exit_code == 0
     with session_obj() as session:
@@ -132,7 +132,7 @@ def test_remove_old_records(session_obj: sa.orm.sessionmaker):
     result = runner.invoke(
         entry_points.app,
         [
-            "remove-old-records",
+            "remove-old-requests",
             "--connection-string",
             connection_string,
             "--older-than-days",
@@ -151,7 +151,7 @@ def test_remove_old_records(session_obj: sa.orm.sessionmaker):
     result = runner.invoke(
         entry_points.app,
         [
-            "remove-old-records",
+            "remove-old-requests",
             "--connection-string",
             connection_string,
             "--older-than-days",

--- a/tests/test_90_entry_points.py
+++ b/tests/test_90_entry_points.py
@@ -1,3 +1,5 @@
+import datetime
+import uuid
 from typing import Any
 
 import cacholote
@@ -8,6 +10,45 @@ from typer.testing import CliRunner
 from cads_broker import database, entry_points, object_storage
 
 runner = CliRunner()
+
+
+def mock_system_request(
+    status: str | None = "accepted",
+    created_at: datetime.datetime = datetime.datetime.now(),
+    request_uid: str | None = None,
+    process_id: str | None = "process_id",
+    user_uid: str | None = None,
+    cache_id: int | None = None,
+    request_body: dict | None = None,
+    request_metadata: dict | None = None,
+    adaptor_properties_hash: str = "",
+    entry_point: str = "entry_point",
+    finished_at: datetime.datetime | None = None,
+) -> database.SystemRequest:
+    system_request = database.SystemRequest(
+        request_uid=request_uid or str(uuid.uuid4()),
+        process_id=process_id,
+        status=status,
+        user_uid=user_uid,
+        created_at=created_at,
+        started_at=None,
+        cache_id=cache_id,
+        request_body=request_body or {"request_type": "test"},
+        request_metadata=request_metadata or {},
+        adaptor_properties_hash=adaptor_properties_hash,
+        entry_point=entry_point,
+        finished_at=finished_at,
+    )
+    return system_request
+
+
+def mock_config(hash: str = "", config: dict[str, Any] = {}, form: dict[str, Any] = {}):
+    adaptor_properties = database.AdaptorProperties(
+        hash=hash,
+        config=config,
+        form=form,
+    )
+    return adaptor_properties
 
 
 def test_init_db(postgresql: Connection[str], mocker) -> None:
@@ -43,3 +84,82 @@ def test_init_db(postgresql: Connection[str], mocker) -> None:
         database.BaseModel.metadata.tables
     ).union({"alembic_version"}).union(set(cacholote.database.Base.metadata.tables))
     conn.close()
+
+
+def test_remove_old_records(session_obj: sa.orm.sessionmaker):
+    now = sa.func.now()
+    old_requests = []
+    unfinished_requests = []
+    recent_requests = []
+    with session_obj() as session:
+        adaptor_properties = mock_config()
+        session.add(adaptor_properties)
+        # create 5 "old" requests
+        finished_at = now - datetime.timedelta(days=360)
+        for request in range(5):
+            request = mock_system_request(finished_at=finished_at)
+            session.add(request)
+            old_requests.append(request.request_uid)
+        # create 5 unfinished requests
+        finished_at = None
+        for request in range(5):
+            request = mock_system_request(finished_at=finished_at)
+            session.add(request)
+            unfinished_requests.append(request.request_uid)
+        # create 5 "recent" requests
+        finished_at = now - datetime.timedelta(days=3)
+        for request in range(5):
+            request = mock_system_request(finished_at=finished_at)
+            session.add(request)
+            recent_requests.append(request.request_uid)
+        session.commit()
+    connection_string = session_obj.kw["bind"].url
+    with session_obj() as session:
+        all_requests = session.query(database.SystemRequest).all()
+        assert len(all_requests) == 15
+
+    # remove nothing, older_than_days=365 by default, and oldest is 360
+    result = runner.invoke(
+        entry_points.app,
+        ["remove-old-records", "--connection-string", connection_string],
+    )
+    assert result.exit_code == 0
+    with session_obj() as session:
+        all_requests = session.query(database.SystemRequest).all()
+        assert len(all_requests) == 15
+
+    # remove 360 day old requests
+    result = runner.invoke(
+        entry_points.app,
+        [
+            "remove-old-records",
+            "--connection-string",
+            connection_string,
+            "--older-than-days",
+            "360",
+        ],
+    )
+    assert result.exit_code == 0
+    with session_obj() as session:
+        all_requests = session.query(database.SystemRequest).all()
+        assert len(all_requests) == 10
+        assert set([r.request_uid for r in all_requests]) == set(recent_requests) | set(
+            unfinished_requests
+        )
+
+    # remove all but unfinished
+    result = runner.invoke(
+        entry_points.app,
+        [
+            "remove-old-records",
+            "--connection-string",
+            connection_string,
+            "--older-than-days",
+            "2",
+        ],
+    )
+    assert result.exit_code == 0
+    with session_obj() as session:
+        all_requests = session.query(database.SystemRequest).all()
+        assert len(all_requests) == 5
+        assert set([r.request_uid for r in all_requests]) == set(unfinished_requests)


### PR DESCRIPTION
In this PR:
* Added an entry point "remove-old-requests" to remove requests older than X days (default days=365)
* the entry points remove also requests-related events (this via a new delete-cascade db rule)
* the old records of adaptor_properties are removed too if they are without any child requests (using a new timestamp column)
* the PK request_id of system_requests is useless (and dangerous, it's an integer sequence instead of a biginteger), so it was removed, the new primary key is request_uid 