### PR TITLE
[WIP] Broker performance optimisation

### DIFF
--- a/cads_broker/database.py
+++ b/cads_broker/database.py
@@ -220,7 +220,9 @@ def get_accepted_requests(
     statement = sa.select(SystemRequest)
     if last_created_at:
         statement = statement.where(SystemRequest.created_at >= last_created_at)
-    statement = statement.where(SystemRequest.status == "accepted").order_by(SystemRequest.created_at)
+    statement = statement.where(SystemRequest.status == "accepted").order_by(
+        SystemRequest.created_at
+    )
     return session.scalars(statement).all()
 
 

--- a/cads_broker/database.py
+++ b/cads_broker/database.py
@@ -224,6 +224,18 @@ def get_accepted_requests(
     return session.scalars(statement).all()
 
 
+def count_accepted_requests_before(
+    session: sa.orm.Session,
+    last_created_at: datetime.datetime,
+) -> int:
+    """Count running requests for user_uid."""
+    statement = (
+        session.query(SystemRequest)
+        .where(SystemRequest.created_at < last_created_at)
+    )
+    return statement.count()
+
+
 def count_finished_requests_per_user_in_session(
     user_uid: str,
     session: sa.orm.Session,

--- a/cads_broker/database.py
+++ b/cads_broker/database.py
@@ -523,7 +523,7 @@ def delete_request_qos_status(
                 created_rules[qos_rule.uid] = qos_rule
         if qos_rule in request.qos_rules:
             request.qos_rules.remove(qos_rule)
-            qos_rule.queued = max(0, qos_rule.queued - 1)
+        qos_rule.queued = max(0, qos_rule.queued - 1)
         qos_rule.running += 1
     return created_rules
 

--- a/cads_broker/database.py
+++ b/cads_broker/database.py
@@ -481,7 +481,7 @@ def add_qos_rule(
 
 
 def increment_qos_rule_running(
-    rules: list, rules_in_db: dict[str, QoSRule], session: sa.orm.Session, **kwargs
+    rules: list, session: sa.orm.Session, rules_in_db: dict[str, QoSRule] = {}, **kwargs
 ):
     """Increment the running counter of a QoS rule."""
     created_rules: dict = {}
@@ -499,7 +499,7 @@ def increment_qos_rule_running(
 
 
 def decrement_qos_rule_running(
-    rules: list, rules_in_db: dict[str, QoSRule], session: sa.orm.Session, **kwargs
+    rules: list, session: sa.orm.Session, rules_in_db: dict[str, QoSRule] = {}, **kwargs
 ):
     """Increment the running counter of a QoS rule."""
     for rule in rules:
@@ -518,8 +518,8 @@ def decrement_qos_rule_running(
 def delete_request_qos_status(
     request_uid: str,
     rules: list,
-    rules_in_db: dict[str, QoSRule],
     session: sa.orm.Session,
+    rules_in_db: dict[str, QoSRule] = {},
     **kwargs,
 ):
     """Delete all QoS rules from a request."""
@@ -544,9 +544,8 @@ def delete_request_qos_status(
 def add_request_qos_status(
     request: SystemRequest,
     rules: list,
-    rules_in_db: dict,
     session: sa.orm.Session,
-    request_uid: str,
+    rules_in_db: dict[str, QoSRule] = {},
     **kwargs,
 ):
     created_rules: dict = {}

--- a/cads_broker/database.py
+++ b/cads_broker/database.py
@@ -214,13 +214,13 @@ def get_running_requests(
 
 def get_accepted_requests(
     session: sa.orm.Session,
+    last_created_at: datetime.datetime | None = None,
 ):
     """Get all accepted requests."""
-    statement = (
-        sa.select(SystemRequest)
-        .where(SystemRequest.status == "accepted")
-        .order_by(SystemRequest.created_at)
-    )
+    statement = sa.select(SystemRequest)
+    if last_created_at:
+        statement = statement.where(SystemRequest.created_at >= last_created_at)
+    statement = statement.where(SystemRequest.status == "accepted").order_by(SystemRequest.created_at)
     return session.scalars(statement).all()
 
 

--- a/cads_broker/database.py
+++ b/cads_broker/database.py
@@ -232,7 +232,7 @@ def count_accepted_requests_before(
     statement = (
         session.query(SystemRequest)
         .where(SystemRequest.status == "accepted")
-        .where(SystemRequest.created_at < last_created_at)
+        .where(SystemRequest.created_at <= last_created_at)
     )
     return statement.count()
 

--- a/cads_broker/database.py
+++ b/cads_broker/database.py
@@ -231,6 +231,7 @@ def count_accepted_requests_before(
     """Count running requests for user_uid."""
     statement = (
         session.query(SystemRequest)
+        .where(SystemRequest.status == "accepted")
         .where(SystemRequest.created_at < last_created_at)
     )
     return statement.count()

--- a/cads_broker/database.py
+++ b/cads_broker/database.py
@@ -437,6 +437,12 @@ def get_qos_rule(uid: str, session: sa.orm.Session):
     return session.scalars(statement).one()
 
 
+def get_qos_rules(session: sa.orm.Session):
+    """Get all QoS rules."""
+    statement = sa.select(QoSRule)
+    return {rule.uid: rule for rule in session.scalars(statement).all()}
+
+
 def add_qos_rule(
     rule,
     session: sa.orm.Session,
@@ -460,56 +466,85 @@ def add_qos_rule(
     return qos_rule
 
 
-def increment_qos_rule_running(rules: list, session: sa.orm.Session):
+def increment_qos_rule_running(
+    rules: list, rules_in_db: dict[str, QoSRule], session: sa.orm.Session, **kwargs
+):
     """Increment the running counter of a QoS rule."""
+    created_rules: dict = {}
     for rule in rules:
-        try:
-            qos_rule = get_qos_rule(str(rule.__hash__()), session)
-        except sqlalchemy.orm.exc.NoResultFound:
-            qos_rule = add_qos_rule(rule=rule, session=session)
+        if (rule_uid := str(rule.__hash__())) in rules_in_db:
+            qos_rule = rules_in_db[rule_uid]
+        else:
+            try:
+                qos_rule = get_qos_rule(rule_uid, session)
+            except sqlalchemy.orm.exc.NoResultFound:
+                qos_rule = add_qos_rule(rule=rule, session=session)
+                created_rules[qos_rule.uid] = qos_rule
         qos_rule.running += 1
-    session.commit()
+    return created_rules
 
 
-def decrement_qos_rule_running(rules: list, session: sa.orm.Session):
+def decrement_qos_rule_running(
+    rules: list, rules_in_db: dict[str, QoSRule], session: sa.orm.Session, **kwargs
+):
     """Increment the running counter of a QoS rule."""
     for rule in rules:
-        try:
-            qos_rule = get_qos_rule(str(rule.__hash__()), session)
-            qos_rule.running = max(0, qos_rule.running - 1)
-        except sqlalchemy.orm.exc.NoResultFound:
-            # this happend when a request is finished after a broker restart.
-            # the rule is not in the database anymore because it has been reset.
-            continue
-    session.commit()
+        if (rule_uid := str(rule.__hash__())) in rules_in_db:
+            qos_rule = rules_in_db[rule_uid]
+        else:
+            try:
+                qos_rule = get_qos_rule(rule_uid, session)
+                qos_rule.running = max(0, qos_rule.running - 1)
+            except sqlalchemy.orm.exc.NoResultFound:
+                # this happend when a request is finished after a broker restart.
+                # the rule is not in the database anymore because it has been reset.
+                continue
 
 
-def delete_request_qos_status(request_uid: str, rules: list, session: sa.orm.Session):
+def delete_request_qos_status(
+    request_uid: str,
+    rules: list,
+    rules_in_db: dict[str, QoSRule],
+    session: sa.orm.Session,
+    **kwargs,
+):
     """Delete all QoS rules from a request."""
+    created_rules: dict = {}
     request = get_request(request_uid, session)
     for rule in rules:
-        try:
-            qos_rule = get_qos_rule(str(rule.__hash__()), session)
-        except sqlalchemy.orm.exc.NoResultFound:
-            qos_rule = add_qos_rule(rule=rule, session=session)
+        if (rule_uid := str(rule.__hash__())) in rules_in_db:
+            qos_rule = rules_in_db[rule_uid]
+        else:
+            try:
+                qos_rule = get_qos_rule(rule_uid, session)
+            except sqlalchemy.orm.exc.NoResultFound:
+                qos_rule = add_qos_rule(rule=rule, session=session)
+                created_rules[qos_rule.uid] = qos_rule
         if qos_rule in request.qos_rules:
             request.qos_rules.remove(qos_rule)
             qos_rule.queued = max(0, qos_rule.queued - 1)
         qos_rule.running += 1
-    session.commit()
+    return created_rules
 
 
-def add_request_qos_status(request_uid: str, rules: list, session: sa.orm.Session):
-    request = get_request(request_uid, session)
+def add_request_qos_status(
+    request: SystemRequest,
+    rules: list,
+    rules_in_db: dict,
+    session: sa.orm.Session,
+    **kwargs,
+):
+    created_rules: dict = {}
     for rule in rules:
-        try:
-            qos_rule = get_qos_rule(str(rule.__hash__()), session)
-        except sqlalchemy.orm.exc.NoResultFound:
+        if (rule_uid := str(rule.__hash__())) in rules_in_db:
+            qos_rule = rules_in_db[rule_uid]
+        else:
             qos_rule = add_qos_rule(rule=rule, session=session)
+            created_rules[qos_rule.uid] = qos_rule
         if qos_rule not in request.qos_rules:
             qos_rule.queued += 1
             request.qos_rules.append(qos_rule)
-    session.commit()
+    return created_rules
 
 
 def get_qos_status_from_request(
@@ -665,6 +700,15 @@ def add_event(
     session.commit()
 
 
+def dictify_request(request: SystemRequest) -> dict[str, Any]:
+    ret_value = {
+        column.key: getattr(request, column.key)
+        for column in sa.inspect(request).mapper.column_attrs
+    }
+    ret_value["qos_rules"] = [rule.uid for rule in request.qos_rules]
+    return ret_value
+
+
 def create_request(
     session: sa.orm.Session,
     user_uid: str,
@@ -709,11 +753,7 @@ def create_request(
     session.add(request)
     session.commit()
     logger.info("accepted job", **logger_kwargs(request=request))
-    ret_value = {
-        column.key: getattr(request, column.key)
-        for column in sa.inspect(request).mapper.column_attrs
-    }
-    return ret_value
+    return dictify_request(request)
 
 
 def get_request(

--- a/cads_broker/dispatcher.py
+++ b/cads_broker/dispatcher.py
@@ -114,7 +114,7 @@ def perf_logger(func):
         start = time.perf_counter()
         result = func(*args, **kwargs)
         stop = time.perf_counter()
-        logger.debug("performance", function=func.__name__, elapsed=stop - start)
+        logger.info("performance", function=func.__name__, elapsed=stop - start)
         return result
 
     return wrapper

--- a/cads_broker/dispatcher.py
+++ b/cads_broker/dispatcher.py
@@ -135,6 +135,7 @@ class Queue:
         with self._lock:
             self.queue_dict[key] = item
 
+    @perf_logger
     def add_accepted_requests(self, accepted_requests: dict) -> None:
         with self._lock:
             for request in accepted_requests:

--- a/cads_broker/dispatcher.py
+++ b/cads_broker/dispatcher.py
@@ -112,7 +112,8 @@ class Queue:
     def __init__(self) -> None:
         self.queue_dict: dict = dict()
         self._lock = threading.RLock()
-        self.last_created_at: datetime.datetime | None = None
+        # default value is before the release
+        self.last_created_at: datetime.datetime = datetime.datetime(2024, 1, 1)
 
     def get(self, key: str, default=None) -> Any:
         with self._lock:

--- a/cads_broker/dispatcher.py
+++ b/cads_broker/dispatcher.py
@@ -308,7 +308,9 @@ class Broker:
                 exception = future.exception()
                 error_message = "".join(traceback.format_exception(exception))
                 error_reason = exception.__class__.__name__
-                if error_reason == "distributed.scheduler.KilledWorker":
+                if error_reason == "distributed.scheduler.KilledWorker" and os.getenv(
+                    "BROKER_REQUEUE_ON_KILLED_WORKER", False
+                ):
                     logger.info("worker killed: re-queueing", job_id=future.key)
                     db.requeue_request(request_uid=future.key, session=session)
                     self.queue.add(request.request_uid, request)
@@ -417,7 +419,7 @@ class Broker:
                     self.queue.add_accepted_requests(
                         db.get_accepted_requests(
                             session=session_write,
-                            last_created_at=self.queue.last_created_at
+                            last_created_at=self.queue.last_created_at,
                         )
                     )
                     self.sync_database(session=session_write)

--- a/cads_broker/dispatcher.py
+++ b/cads_broker/dispatcher.py
@@ -362,6 +362,7 @@ class Broker:
                 # expire_on_commit=False is used to detach the accepted requests without an error
                 # this is not a problem because accepted requests cannot be modified in this loop
                 with self.session_maker_write(expire_on_commit=False) as session_write:
+                    start = time.time()
                     accepted_requests = {
                         r.request_uid: r
                         for r in db.get_accepted_requests(session=session_write)
@@ -369,6 +370,8 @@ class Broker:
                     self.sync_database(session=session_write)
                     self.sync_qos_rules(accepted_requests, session_write)
                     session_write.commit()
+                    stop = time.time()
+                    print("SYNC DATABASE IN ", stop - start)
 
                 self.running_requests = len(
                     [

--- a/cads_broker/dispatcher.py
+++ b/cads_broker/dispatcher.py
@@ -215,7 +215,9 @@ class Broker:
                 )
 
     def sync_qos_rules(self, accepted_requests, session_write) -> None:
+        start = time.time()
         qos_rules = db.get_qos_rules(session=session_write)
+        print(f"PROCESSING {len(self.internal_scheduler.queue)} TASKS")
         for task in list(self.internal_scheduler.queue):
             # the internal scheduler is used to asynchronously add qos rules to database
             # it returns a new qos rule if a new qos rule is added to database
@@ -231,6 +233,9 @@ class Broker:
             # if a new qos rule is added, the new qos rule is added to the list of qos rules
             if new_qos_rules:
                 qos_rules.update(new_qos_rules)
+        stop = time.time()
+        print("QOS ADDED IN ", stop - start)
+        print(f"TASKS ARE NOW {len(self.internal_scheduler.queue)}")
 
     def on_future_done(self, future: distributed.Future) -> None:
         job_status = DASK_STATUS_TO_STATUS.get(future.status, "accepted")

--- a/cads_broker/dispatcher.py
+++ b/cads_broker/dispatcher.py
@@ -363,10 +363,13 @@ class Broker:
                 # this is not a problem because accepted requests cannot be modified in this loop
                 with self.session_maker_write(expire_on_commit=False) as session_write:
                     start = time.time()
+                    start_accepted = time.time()
                     accepted_requests = {
                         r.request_uid: r
                         for r in db.get_accepted_requests(session=session_write)
                     }
+                    stop_accepted = time.time()
+                    print("ACCEPTED REQUESTS IN ", stop_accepted - start_accepted)
                     self.sync_database(session=session_write)
                     self.sync_qos_rules(accepted_requests, session_write)
                     session_write.commit()

--- a/cads_broker/entry_points.py
+++ b/cads_broker/entry_points.py
@@ -17,12 +17,12 @@ app = typer.Typer()
 
 
 @app.command()
-def add_dummy_requests(number_of_requests: int, requests_db: str, number_of_users: int = 1000) -> None:
+def add_dummy_requests(
+    number_of_requests: int, requests_db: str, number_of_users: int = 1000
+) -> None:
     connection = sqlite3.connect(requests_db)
     connection.row_factory = sqlite3.Row
-    cursor = connection.execute(
-        f"SELECT * FROM broker limit {number_of_requests}"
-    )
+    cursor = connection.execute(f"SELECT * FROM broker limit {number_of_requests}")
     user_uids = [str(uuid.uuid4()) for _ in range(number_of_users)]
     with database.ensure_session_obj(None)() as session:
         for i, row in enumerate(cursor):
@@ -46,8 +46,8 @@ def add_dummy_requests(number_of_requests: int, requests_db: str, number_of_user
                         },
                     },
                     request_metadata={},
-                    origin='api',
-                    portal='c3s',
+                    origin="api",
+                    portal="c3s",
                     adaptor_properties_hash="test",
                     entry_point="cads_adaptors:DummyAdaptor",
                 )

--- a/cads_broker/qos/QoS.py
+++ b/cads_broker/qos/QoS.py
@@ -101,7 +101,7 @@ class QoS:
         for i, limit in enumerate(properties.limits):
             if limit.full(request):
                 limits.append(limit)
-                if str(limit.__hash__()) not in request.qos_rules:
+                if str(limit.__hash__()) not in [r.uid for r in request.qos_rules]:
                     limits_to_add.append(limit)
         if len(limits_to_add):
             scheduler.append(

--- a/cads_broker/qos/QoS.py
+++ b/cads_broker/qos/QoS.py
@@ -97,10 +97,13 @@ class QoS:
         """Check if a request can run."""
         properties = self._properties(request=request, session=session)
         limits = []
+        limits_to_add = []
         for i, limit in enumerate(properties.limits):
             if limit.full(request):
                 limits.append(limit)
-        if len(limits):
+                if str(limit.__hash__()) not in request.qos_rules:
+                    limits_to_add.append(limit)
+        if len(limits_to_add):
             scheduler.append(
                 {
                     "function": database.add_request_qos_status,

--- a/cads_broker/qos/QoS.py
+++ b/cads_broker/qos/QoS.py
@@ -8,7 +8,6 @@
 #
 
 import threading
-import time
 from functools import wraps
 
 from .. import database
@@ -102,15 +101,14 @@ class QoS:
             if limit.full(request):
                 limits.append(limit)
         if len(limits):
-            scheduler.enterabs(
-                time.time(),
-                1,
-                database.add_request_qos_status,
-                kwargs={
-                    "request_uid": request.request_uid,
-                    "rules": limits,
-                    "session": session,
-                },
+            scheduler.append(
+                {
+                    "function": database.add_request_qos_status,
+                    "kwargs": {
+                        "request_uid": request.request_uid,
+                        "rules": limits,
+                    },
+                }
             )
         session.commit()
         permissions = []
@@ -304,15 +302,14 @@ class QoS:
         for limit in self.limits_for(request, session):
             limit.increment()
             limits_list.append(limit)
-        scheduler.enterabs(
-            time.time(),
-            1,
-            database.delete_request_qos_status,
-            kwargs={
-                "rules": limits_list,
-                "request_uid": request.request_uid,
-                "session": session,
-            },
+        scheduler.append(
+            {
+                "function": database.delete_request_qos_status,
+                "kwargs": {
+                    "rules": limits_list,
+                    "request_uid": request.request_uid,
+                },
+            }
         )
         # Keep track of the running request. This is needed by reconfigure(self)
 
@@ -328,14 +325,13 @@ class QoS:
             limit.decrement()
             limits_list.append(limit)
 
-        scheduler.enterabs(
-            time.time(),
-            1,
-            database.decrement_qos_rule_running,
-            kwargs={
-                "rules": limits_list,
-                "session": session,
-            },
+        scheduler.append(
+            {
+                "function": database.decrement_qos_rule_running,
+                "kwargs": {
+                    "rules": limits_list,
+                },
+            }
         )
 
         # Remove requests all collections


### PR DESCRIPTION
The primary bottlenecks of the broker implementation are as follows:

- The broker loads all accepted requests from the database during each loop. If the number of accepted requests is high (around 50k requests), this process may take considerable time (approximately 10 seconds).
- The broker updates the `qos_rules` table during each loop, requiring a check of the `qos_rules` table for each request in the queue. If the number of accepted requests is high (around 50k requests), this operation may take a significant amount of time (approximately 30 seconds).

If these two operations are slow, the number of submitted requests will be lower than the number of finished requests, causing the queue to continually increase and further reducing performance.

This pull request addresses both bottlenecks:

- Accepted requests are now stored in memory within a dedicated `Queue` class. This class is responsible for fetching only newly accepted requests from the database, significantly improving performance as the slow operation of fetching all accepted requests is now only performed during startup.
- QoS rules are now fetched from the database only once and then updated for each request. Additionally, an optimization has been implemented on the PostgreSQL sessions, ensuring that all database operations are performed within a single session.

Minor improvements:

- A performance logger has been introduced, which logs the time spent on time-consuming operations.
- The `time.sleep` at the end of each broker loop now takes into account the time spent in the loop, enhancing the accuracy of the sleep interval.
 