### PR TITLE
Fix long running requests and QoS status

### DIFF
--- a/cads_broker/Environment.py
+++ b/cads_broker/Environment.py
@@ -23,8 +23,8 @@ def locked(method):
 
 
 class Environment:
-    def __init__(self):
-        self.number_of_workers = 0
+    def __init__(self, numer_of_workers=0):
+        self.number_of_workers = numer_of_workers
         self.session = None
         self.lock = threading.RLock()
         self._enabled = {}

--- a/cads_broker/Environment.py
+++ b/cads_broker/Environment.py
@@ -23,8 +23,8 @@ def locked(method):
 
 
 class Environment:
-    def __init__(self, numer_of_workers=0):
-        self.number_of_workers = numer_of_workers
+    def __init__(self, number_of_workers=0):
+        self.number_of_workers = number_of_workers
         self.session = None
         self.lock = threading.RLock()
         self._enabled = {}

--- a/cads_broker/database.py
+++ b/cads_broker/database.py
@@ -533,9 +533,7 @@ def decrement_qos_rule_running(
                 # this happend when a request is finished after a broker restart.
                 # the rule is not in the database anymore because it has been reset.
                 continue
-        logger.info(f"----------------- decrementing {qos_rule.info}: {qos_rule.running}")
         qos_rule.running = max(0, qos_rule.running - 1)
-        logger.info(f"----------------- decremented {qos_rule.info}: {qos_rule.running}")
     return None, None
 
 
@@ -560,6 +558,8 @@ def delete_request_qos_status(
                 created_rules[qos_rule.uid] = qos_rule
         if qos_rule.uid in [r.uid for r in request.qos_rules]:
             request.qos_rules.remove(qos_rule)
+        if qos_rule.running > 99:
+            logger.info(f"----------------- incrementing to {qos_rule.running + 1}")
         qos_rule.queued = max(0, qos_rule.queued - 1)
         qos_rule.running += 1
     return request, created_rules

--- a/cads_broker/database.py
+++ b/cads_broker/database.py
@@ -522,7 +522,7 @@ def add_qos_rule(
 def decrement_qos_rule_running(
     rules: list, session: sa.orm.Session, rules_in_db: dict[str, QoSRule] = {}, **kwargs
 ):
-    """Increment the running counter of a QoS rule."""
+    """Decrement the running counter of a QoS rule."""
     for rule in rules:
         if (rule_uid := str(rule.__hash__())) in rules_in_db:
             qos_rule = rules_in_db[rule_uid]
@@ -533,7 +533,9 @@ def decrement_qos_rule_running(
                 # this happend when a request is finished after a broker restart.
                 # the rule is not in the database anymore because it has been reset.
                 continue
+        logger.info(f"----------------- decrementing {qos_rule.info}: {qos_rule.running}")
         qos_rule.running = max(0, qos_rule.running - 1)
+        logger.info(f"----------------- decremented {qos_rule.info}: {qos_rule.running}")
     return None, None
 
 

--- a/cads_broker/database.py
+++ b/cads_broker/database.py
@@ -587,7 +587,8 @@ def add_request_qos_status(
                 new_request.qos_rules.append(qos_rule)
             except Exception:
                 print("------------- uids", [str(rule.__hash__()) for rule in rules])
-                print("------------- rules", rules)
+                print("------------- rules", request.qos_rules)
+                raise
     return new_request, created_rules
 
 

--- a/cads_broker/database.py
+++ b/cads_broker/database.py
@@ -533,7 +533,7 @@ def decrement_qos_rule_running(
                 # this happend when a request is finished after a broker restart.
                 # the rule is not in the database anymore because it has been reset.
                 continue
-        qos_rule.running = max(0, qos_rule.running - 1)
+        qos_rule.running = rule.value
     return None, None
 
 
@@ -558,10 +558,8 @@ def delete_request_qos_status(
                 created_rules[qos_rule.uid] = qos_rule
         if qos_rule.uid in [r.uid for r in request.qos_rules]:
             request.qos_rules.remove(qos_rule)
-        if qos_rule.running > 99:
-            logger.info(f"----------------- incrementing to {qos_rule.running + 1}")
-        qos_rule.queued = max(0, qos_rule.queued - 1)
-        qos_rule.running += 1
+        qos_rule.queued = rule.queued
+        qos_rule.running = rule.value
     return request, created_rules
 
 
@@ -583,7 +581,7 @@ def add_request_qos_status(
             qos_rule = add_qos_rule(rule=rule, session=session)
             created_rules[qos_rule.uid] = qos_rule
         if qos_rule.uid not in [r.uid for r in request.qos_rules]:
-            qos_rule.queued += 1
+            qos_rule.queued = rule.queued
             new_request = get_request(request.request_uid, session)
             new_request.qos_rules.append(qos_rule)
     return new_request, created_rules

--- a/cads_broker/database.py
+++ b/cads_broker/database.py
@@ -556,7 +556,7 @@ def delete_request_qos_status(
             except sqlalchemy.orm.exc.NoResultFound:
                 qos_rule = add_qos_rule(rule=rule, session=session)
                 created_rules[qos_rule.uid] = qos_rule
-        if qos_rule in request.qos_rules:
+        if qos_rule.uid in [r.uid for r in request.qos_rules]:
             request.qos_rules.remove(qos_rule)
         qos_rule.queued = max(0, qos_rule.queued - 1)
         qos_rule.running += 1
@@ -581,14 +581,9 @@ def add_request_qos_status(
             qos_rule = add_qos_rule(rule=rule, session=session)
             created_rules[qos_rule.uid] = qos_rule
         if qos_rule.uid not in [r.uid for r in request.qos_rules]:
-            try:
-                qos_rule.queued += 1
-                new_request = get_request(request.request_uid, session)
-                new_request.qos_rules.append(qos_rule)
-            except Exception:
-                print("------------- uids", [str(rule.__hash__()) for rule in rules])
-                print("------------- rules", [rule.uid for rule in request.qos_rules])
-                raise
+            qos_rule.queued += 1
+            new_request = get_request(request.request_uid, session)
+            new_request.qos_rules.append(qos_rule)
     return new_request, created_rules
 
 

--- a/cads_broker/database.py
+++ b/cads_broker/database.py
@@ -558,7 +558,7 @@ def delete_request_qos_status(
                 created_rules[qos_rule.uid] = qos_rule
         if qos_rule.uid in [r.uid for r in request.qos_rules]:
             request.qos_rules.remove(qos_rule)
-        qos_rule.queued = rule.queued
+        qos_rule.queued = len(rule.queued)
         qos_rule.running = rule.value
     return request, created_rules
 
@@ -581,7 +581,7 @@ def add_request_qos_status(
             qos_rule = add_qos_rule(rule=rule, session=session)
             created_rules[qos_rule.uid] = qos_rule
         if qos_rule.uid not in [r.uid for r in request.qos_rules]:
-            qos_rule.queued = rule.queued
+            qos_rule.queued = len(rule.queued)
             new_request = get_request(request.request_uid, session)
             new_request.qos_rules.append(qos_rule)
     return new_request, created_rules

--- a/cads_broker/database.py
+++ b/cads_broker/database.py
@@ -636,8 +636,6 @@ def set_request_status(
     cache_id: int | None = None,
     error_message: str | None = None,
     error_reason: str | None = None,
-    log: list[tuple[int, str]] = [],
-    user_visible_log: list[tuple[int, str]] = [],
     resubmit: bool | None = None,
 ) -> SystemRequest:
     """Set the status of a request."""
@@ -661,8 +659,6 @@ def set_request_status(
         request.started_at = sa.func.now()
         request.qos_status = {}
     # FIXME: logs can't be live updated
-    request.response_log = json.dumps(log)
-    request.response_user_visible_log = json.dumps(user_visible_log)
     request.status = status
     session.commit()
     return request

--- a/cads_broker/database.py
+++ b/cads_broker/database.py
@@ -637,6 +637,20 @@ def set_request_cache_id(request_uid: str, cache_id: int, session: sa.orm.Sessio
     return request
 
 
+def set_successful_request(
+    request_uid: str,
+    session: sa.orm.Session,
+) -> SystemRequest:
+    statement = sa.select(SystemRequest).where(SystemRequest.request_uid == request_uid)
+    request = session.scalars(statement).one()
+    if request.status == "successful":
+        return
+    request.status = "successful"
+    request.finished_at = sa.func.now()
+    session.commit()
+    return request
+
+
 def set_request_status(
     request_uid: str,
     status: str,

--- a/cads_broker/database.py
+++ b/cads_broker/database.py
@@ -584,7 +584,6 @@ def add_request_qos_status(
             qos_rule.queued += 1
             new_request = get_request(request.request_uid, session)
             new_request.qos_rules.append(qos_rule)
-            session.flush()
     return new_request, created_rules
 
 

--- a/cads_broker/database.py
+++ b/cads_broker/database.py
@@ -581,9 +581,13 @@ def add_request_qos_status(
             qos_rule = add_qos_rule(rule=rule, session=session)
             created_rules[qos_rule.uid] = qos_rule
         if qos_rule not in request.qos_rules:
-            qos_rule.queued += 1
-            new_request = get_request(request.request_uid, session)
-            new_request.qos_rules.append(qos_rule)
+            try:
+                qos_rule.queued += 1
+                new_request = get_request(request.request_uid, session)
+                new_request.qos_rules.append(qos_rule)
+            except Exception:
+                print("------------- uids", [str(rule.__hash__()) for rule in rules])
+                print("------------- rules", rules)
     return new_request, created_rules
 
 

--- a/cads_broker/database.py
+++ b/cads_broker/database.py
@@ -583,10 +583,7 @@ def add_request_qos_status(
         if qos_rule not in request.qos_rules:
             qos_rule.queued += 1
             new_request = get_request(request.request_uid, session)
-            try:
-                new_request.qos_rules.append(qos_rule)
-            except sqlalchemy.exc.IntegrityError:
-                continue
+            new_request.qos_rules.append(qos_rule)
     return new_request, created_rules
 
 

--- a/cads_broker/database.py
+++ b/cads_broker/database.py
@@ -587,7 +587,7 @@ def add_request_qos_status(
                 new_request.qos_rules.append(qos_rule)
             except Exception:
                 print("------------- uids", [str(rule.__hash__()) for rule in rules])
-                print("------------- rules", request.qos_rules)
+                print("------------- rules", [rule.uid for rule in request.qos_rules])
                 raise
     return new_request, created_rules
 

--- a/cads_broker/database.py
+++ b/cads_broker/database.py
@@ -582,8 +582,8 @@ def add_request_qos_status(
             created_rules[qos_rule.uid] = qos_rule
         # if qos_rule not in request.qos_rules:
         qos_rule.queued += 1
-        new_request = get_request(request.request_uid, session)
         try:
+            new_request = get_request(request.request_uid, session)
             new_request.qos_rules.append(qos_rule)
         except sqlalchemy.exc.IntegrityError:
             continue

--- a/cads_broker/database.py
+++ b/cads_broker/database.py
@@ -580,7 +580,7 @@ def add_request_qos_status(
         else:
             qos_rule = add_qos_rule(rule=rule, session=session)
             created_rules[qos_rule.uid] = qos_rule
-        if qos_rule not in request.qos_rules:
+        if qos_rule.uid not in [r.uid for r in request.qos_rules]:
             try:
                 qos_rule.queued += 1
                 new_request = get_request(request.request_uid, session)

--- a/cads_broker/database.py
+++ b/cads_broker/database.py
@@ -608,11 +608,9 @@ def get_qos_status_from_request(
 
 
 def requeue_request(
-    request_uid: str,
+    request: SystemRequest,
     session: sa.orm.Session,
-):
-    statement = sa.select(SystemRequest).where(SystemRequest.request_uid == request_uid)
-    request = session.scalars(statement).one()
+) -> SystemRequest | None:
     if request.status == "running":
         # ugly implementation because sqlalchemy doesn't allow to directly update JSONB
         # FIXME: use a specific column for resubmit_number
@@ -626,7 +624,7 @@ def requeue_request(
         logger.info("requeueing request", **logger_kwargs(request=request))
         return request
     else:
-        return
+        return None
 
 
 def set_request_cache_id(request_uid: str, cache_id: int, session: sa.orm.Session):
@@ -640,11 +638,11 @@ def set_request_cache_id(request_uid: str, cache_id: int, session: sa.orm.Sessio
 def set_successful_request(
     request_uid: str,
     session: sa.orm.Session,
-) -> SystemRequest:
+) -> SystemRequest | None:
     statement = sa.select(SystemRequest).where(SystemRequest.request_uid == request_uid)
     request = session.scalars(statement).one()
     if request.status == "successful":
-        return
+        return None
     request.status = "successful"
     request.finished_at = sa.func.now()
     session.commit()

--- a/cads_broker/database.py
+++ b/cads_broker/database.py
@@ -580,13 +580,13 @@ def add_request_qos_status(
         else:
             qos_rule = add_qos_rule(rule=rule, session=session)
             created_rules[qos_rule.uid] = qos_rule
-        # if qos_rule not in request.qos_rules:
-        qos_rule.queued += 1
-        try:
+        if qos_rule not in request.qos_rules:
+            qos_rule.queued += 1
             new_request = get_request(request.request_uid, session)
-            new_request.qos_rules.append(qos_rule)
-        except sqlalchemy.exc.IntegrityError:
-            continue
+            try:
+                new_request.qos_rules.append(qos_rule)
+            except sqlalchemy.exc.IntegrityError:
+                continue
     return new_request, created_rules
 
 

--- a/cads_broker/database.py
+++ b/cads_broker/database.py
@@ -584,6 +584,7 @@ def add_request_qos_status(
             qos_rule.queued += 1
             new_request = get_request(request.request_uid, session)
             new_request.qos_rules.append(qos_rule)
+            session.flush()
     return new_request, created_rules
 
 

--- a/cads_broker/dispatcher.py
+++ b/cads_broker/dispatcher.py
@@ -466,7 +466,6 @@ class Broker:
             else:
                 # if the dask status is cancelled, the qos has already been reset by sync_database
                 return
-            future.release()
             # self.futures.pop(future.key, None)
             if request:
                 self.qos.notify_end_of_request(
@@ -477,6 +476,7 @@ class Broker:
                 dask_status=future.status,
                 **db.logger_kwargs(request=request),
             )
+            future.release()
         return future.key
 
     def submit_requests(

--- a/cads_broker/dispatcher.py
+++ b/cads_broker/dispatcher.py
@@ -400,7 +400,11 @@ class Broker:
         with self.session_maker_write() as session:
             if future.status == "finished":
                 # the result is updated in the database by the worker
-                request = db.get_request(future.key, session=session)
+                request = db.set_request_status(
+                    request_uid=future.key,
+                    status="successful",
+                    session=session,
+                )
             elif future.status == "error":
                 exception = future.exception()
                 request = self.set_request_error_status(

--- a/cads_broker/dispatcher.py
+++ b/cads_broker/dispatcher.py
@@ -431,6 +431,7 @@ class Broker:
                 )
             else:
                 # if the dask status is cancelled, the qos has already been reset by sync_database
+                logger.info(f"------------------------Sono nel posto sbagliato {future.key}, {future.status}")
                 return
             self.futures.pop(future.key, None)
             self.qos.notify_end_of_request(

--- a/cads_broker/dispatcher.py
+++ b/cads_broker/dispatcher.py
@@ -311,10 +311,16 @@ class Broker:
         scheduler_tasks = get_tasks_from_scheduler(self.client)
         requests = session.scalars(statement).all()
         if len(scheduler_tasks) == 0 and len(self.futures):
-            logger.info(f"Scheduler is empty, but futures are {len(self.futures)}. Resetting futures.")
+            logger.info(
+                f"Scheduler is empty, but futures are {len(self.futures)}. Resetting futures."
+            )
             self.futures = {}
-        logger.info(f"Futures not in scheduler: {set(self.futures.keys()) - set(scheduler_tasks.keys())}")
-        logger.info(f"Scheduler tasks not in futures: {set(scheduler_tasks.keys()) - set(self.futures.keys())}")
+        logger.info(
+            f"Futures not in scheduler: {set(self.futures.keys()) - set(scheduler_tasks.keys())}"
+        )
+        logger.info(
+            f"Scheduler tasks not in futures: {[(uid, scheduler_tasks[uid]) for uid in set(scheduler_tasks.keys()) - set(self.futures.keys())]}"
+        )
         for request in requests:
             # if request is in futures, go on
             if request.request_uid in self.futures:
@@ -353,7 +359,9 @@ class Broker:
                     logger.info(
                         "request not found: re-queueing", job_id={request.request_uid}
                     )
-                    request = db.requeue_request(request_uid=request.request_uid, session=session)
+                    request = db.requeue_request(
+                        request_uid=request.request_uid, session=session
+                    )
                     if request:
                         self.queue.add(request.request_uid, request)
                         self.qos.notify_end_of_request(

--- a/cads_broker/dispatcher.py
+++ b/cads_broker/dispatcher.py
@@ -330,6 +330,11 @@ class Broker:
                     # if the task is in memory and it is not in the futures
                     # it means that the task has been lost by the broker (broker has been restarted)
                     # the task is successful.
+                    request = db.set_request_status(
+                        request_uid=request.request_uid,
+                        status="successful",
+                        session=session,
+                    )
                     self.qos.notify_end_of_request(
                         request, session, scheduler=self.internal_scheduler
                     )

--- a/cads_broker/dispatcher.py
+++ b/cads_broker/dispatcher.py
@@ -1,4 +1,5 @@
 import datetime
+import functools
 import hashlib
 import io
 import os
@@ -525,7 +526,7 @@ class Broker:
             metadata=request.request_metadata,
         )
         self.futures[request.request_uid] = future
-        future.add_done_callback(self.on_future_done, pop=True)
+        future.add_done_callback(functools.partial(self.on_future_done, pop=True))
         logger.info(
             "submitted job to scheduler",
             **db.logger_kwargs(request=request),

--- a/cads_broker/dispatcher.py
+++ b/cads_broker/dispatcher.py
@@ -507,18 +507,20 @@ class Broker:
             request, session, scheduler=self.internal_scheduler
         )
         self.queue.pop(request.request_uid)
+        config = self.client.scatter(dict(
+                request_uid=request.request_uid,
+                user_uid=request.user_uid,
+                hostname=os.getenv("CDS_PROJECT_URL"),
+                **request.adaptor_properties.config,
+        ))
+        form = self.client.scatter(request.adaptor_properties.form)
         future = self.client.submit(
             worker.submit_workflow,
             key=request.request_uid,
             setup_code=request.request_body.get("setup_code", ""),
             entry_point="cads_adaptors:DummyAdaptor",
-            config=dict(
-                request_uid=request.request_uid,
-                user_uid=request.user_uid,
-                hostname=os.getenv("CDS_PROJECT_URL"),
-                **request.adaptor_properties.config,
-            ),
-            form=request.adaptor_properties.form,
+            config=config,
+            form=form,
             request=request.request_body.get("request", {}),
             resources=request.request_metadata.get("resources", {}),
             metadata=request.request_metadata,

--- a/cads_broker/dispatcher.py
+++ b/cads_broker/dispatcher.py
@@ -316,7 +316,12 @@ class Broker:
             db.SystemRequest.status == "running"
         )
         scheduler_tasks = get_tasks_from_scheduler(self.client)
-        for request in session.scalars(statement):
+        requests = session.scalars(statement).all()
+        logger.info(
+            f"Running requests: db {len(requests)}, " \
+            f"scheduler {len(scheduler_tasks)}, futures {len(self.futures)}"
+        )
+        for request in requests:
             # if request is in futures, go on
             if request.request_uid in self.futures:
                 continue

--- a/cads_broker/dispatcher.py
+++ b/cads_broker/dispatcher.py
@@ -330,18 +330,18 @@ class Broker:
                     # if the task is in memory and it is not in the futures
                     # it means that the task has been lost by the broker (broker has been restarted)
                     # the task is successful.
-                    request = db.set_successful_request(
+                    successful_request = db.set_successful_request(
                         request_uid=request.request_uid,
                         session=session,
                     )
-                    if request:
+                    if successful_request:
                         self.qos.notify_end_of_request(
-                            request, session, scheduler=self.internal_scheduler
+                            successful_request, session, scheduler=self.internal_scheduler
                         )
                         logger.info(
                             "job has finished",
                             dask_status=task["state"],
-                            **db.logger_kwargs(request=request),
+                            **db.logger_kwargs(request=successful_request),
                         )
                 elif state == "erred":
                     exception = pickle.loads(task["exception"])

--- a/cads_broker/dispatcher.py
+++ b/cads_broker/dispatcher.py
@@ -396,13 +396,7 @@ class Broker:
         with self.session_maker_write() as session:
             if future.status == "finished":
                 # the result is updated in the database by the worker
-                result = future.result()
-                request = db.set_request_status(
-                    future.key,
-                    job_status,
-                    cache_id=result,
-                    session=session,
-                )
+                pass
             elif future.status == "error":
                 exception = future.exception()
                 request = self.set_request_error_status(

--- a/cads_broker/dispatcher.py
+++ b/cads_broker/dispatcher.py
@@ -440,6 +440,8 @@ class Broker:
             request, session, scheduler=self.internal_scheduler
         )
         self.queue.pop(request.request_uid)
+        request_body = request.request_body
+        request_body["elapsed"] = "0:00:30.204614"
         future = self.client.submit(
             worker.submit_workflow,
             key=request.request_uid,

--- a/cads_broker/dispatcher.py
+++ b/cads_broker/dispatcher.py
@@ -219,6 +219,7 @@ class Broker:
             qos_config.environment,
             rules_hash=rules_hash,
         )
+        qos.reload_rules(session=session_maker_read)
         with session_maker_write() as session:
             db.reset_qos_rules(session, qos)
         self = cls(

--- a/cads_broker/dispatcher.py
+++ b/cads_broker/dispatcher.py
@@ -454,7 +454,7 @@ class Broker:
                 **request.adaptor_properties.config,
             ),
             form=request.adaptor_properties.form,
-            request=request.request_body.get("request", {}),
+            request=request_body,
             resources=request.request_metadata.get("resources", {}),
             metadata=request.request_metadata,
         )

--- a/cads_broker/dispatcher.py
+++ b/cads_broker/dispatcher.py
@@ -426,7 +426,7 @@ class Broker:
     @perf_logger
     def sync_futures(self) -> None:
         finished_futures = []
-        for future in self.futures.values():
+        for future in list(self.futures.values()):
             if future.status in ("finished", "error", "cancelled"):
                 finished_futures.append(self.on_future_done(future))
         for key in finished_futures:

--- a/cads_broker/dispatcher.py
+++ b/cads_broker/dispatcher.py
@@ -219,8 +219,8 @@ class Broker:
             qos_config.environment,
             rules_hash=rules_hash,
         )
-        qos.reload_rules(session=session_maker_read)
         with session_maker_write() as session:
+            qos.reload_rules(session=session)
             db.reset_qos_rules(session, qos)
         self = cls(
             client=client,

--- a/cads_broker/dispatcher.py
+++ b/cads_broker/dispatcher.py
@@ -318,10 +318,9 @@ class Broker:
         )
         scheduler_tasks = get_tasks_from_scheduler(self.client)
         requests = session.scalars(statement).all()
-        logger.info(
-            f"Running requests: db {len(requests)}, " \
-            f"scheduler {len(scheduler_tasks)}, futures {len(self.futures)}"
-        )
+        if len(scheduler_tasks) == 0 and len(self.futures):
+            logger.info(f"Scheduler is empty, but futures are {len(self.futures)}. Resetting futures.")
+            self.futures = {}
         for request in requests:
             # if request is in futures, go on
             if request.request_uid in self.futures:

--- a/cads_broker/dispatcher.py
+++ b/cads_broker/dispatcher.py
@@ -114,7 +114,7 @@ def perf_logger(func):
         start = time.perf_counter()
         result = func(*args, **kwargs)
         stop = time.perf_counter()
-        if (elapsed := stop - start) > 1:
+        if (elapsed := stop - start) > .1:
             logger.info("performance", function=func.__name__, elapsed=elapsed)
         return result
 
@@ -424,6 +424,7 @@ class Broker:
             if new_qos_rules:
                 qos_rules.update(new_qos_rules)
 
+    @perf_logger
     def sync_futures(self) -> None:
         finished_futures = []
         for future in self.futures.values():

--- a/cads_broker/dispatcher.py
+++ b/cads_broker/dispatcher.py
@@ -318,7 +318,7 @@ class Broker:
             self.internal_scheduler.remove(task)
             # if a new qos rule is added, the new qos rule is added to the list of qos rules
             if request:
-                self.queue.add(request.request_uid, request)
+                self.queue.add(task["kwargs"].get("request_uid"), request)
             if new_qos_rules:
                 qos_rules.update(new_qos_rules)
 

--- a/cads_broker/dispatcher.py
+++ b/cads_broker/dispatcher.py
@@ -122,7 +122,8 @@ def perf_logger(func):
         start = time.perf_counter()
         result = func(*args, **kwargs)
         stop = time.perf_counter()
-        logger.info("performance", function=func.__name__, elapsed=stop - start)
+        if (elapsed := stop - start) > 1:
+            logger.info("performance", function=func.__name__, elapsed=elapsed)
         return result
 
     return wrapper

--- a/cads_broker/dispatcher.py
+++ b/cads_broker/dispatcher.py
@@ -507,20 +507,18 @@ class Broker:
             request, session, scheduler=self.internal_scheduler
         )
         self.queue.pop(request.request_uid)
-        config = self.client.scatter(dict(
-                request_uid=request.request_uid,
-                user_uid=request.user_uid,
-                hostname=os.getenv("CDS_PROJECT_URL"),
-                **request.adaptor_properties.config,
-        ))
-        form = self.client.scatter(request.adaptor_properties.form)
         future = self.client.submit(
             worker.submit_workflow,
             key=request.request_uid,
             setup_code=request.request_body.get("setup_code", ""),
             entry_point="cads_adaptors:DummyAdaptor",
-            config=config,
-            form=form,
+            config=dict(
+                request_uid=request.request_uid,
+                user_uid=request.user_uid,
+                hostname=os.getenv("CDS_PROJECT_URL"),
+                **request.adaptor_properties.config,
+            ),
+            form=request.adaptor_properties.form,
             request=request.request_body.get("request", {}),
             resources=request.request_metadata.get("resources", {}),
             metadata=request.request_metadata,

--- a/cads_broker/dispatcher.py
+++ b/cads_broker/dispatcher.py
@@ -548,9 +548,9 @@ class Broker:
                             last_created_at=self.queue.last_created_at,
                         )
                     )
+                    self.sync_qos_rules(session_write)
                     self.sync_futures()
                     self.sync_database(session=session_write)
-                    self.sync_qos_rules(session_write)
                     session_write.commit()
                     if (queue_length := self.queue.len()) != (
                         db_queue := db.count_accepted_requests_before(

--- a/cads_broker/dispatcher.py
+++ b/cads_broker/dispatcher.py
@@ -169,8 +169,8 @@ class Queue:
 
 
 class QoSRules:
-    def __init__(self) -> None:
-        self.environment = Environment.Environment()
+    def __init__(self, number_of_workers) -> None:
+        self.environment = Environment.Environment(number_of_workers=number_of_workers)
         self.rules_path = os.getenv("RULES_PATH", "/src/rules.qos")
         if os.path.exists(self.rules_path):
             self.rules = self.rules_path
@@ -209,7 +209,7 @@ class Broker:
         session_maker_write: sa.orm.sessionmaker | None = None,
     ):
         client = distributed.Client(address)
-        qos_config = QoSRules()
+        qos_config = QoSRules(get_number_of_workers(client))
         factory.register_functions()
         session_maker_read = db.ensure_session_obj(session_maker_read, mode="r")
         session_maker_write = db.ensure_session_obj(session_maker_write, mode="w")

--- a/cads_broker/dispatcher.py
+++ b/cads_broker/dispatcher.py
@@ -460,8 +460,6 @@ class Broker:
             request, session, scheduler=self.internal_scheduler
         )
         self.queue.pop(request.request_uid)
-        request_body = request.request_body
-        request_body["elapsed"] = "0:00:30.204614"
         future = self.client.submit(
             worker.submit_workflow,
             key=request.request_uid,
@@ -474,7 +472,7 @@ class Broker:
                 **request.adaptor_properties.config,
             ),
             form=request.adaptor_properties.form,
-            request=request_body,
+            request=request.request_body,
             resources=request.request_metadata.get("resources", {}),
             metadata=request.request_metadata,
         )

--- a/cads_broker/dispatcher.py
+++ b/cads_broker/dispatcher.py
@@ -396,7 +396,7 @@ class Broker:
         with self.session_maker_write() as session:
             if future.status == "finished":
                 # the result is updated in the database by the worker
-                pass
+                request = db.get_request(future.key, session=session)
             elif future.status == "error":
                 exception = future.exception()
                 request = self.set_request_error_status(

--- a/cads_broker/dispatcher.py
+++ b/cads_broker/dispatcher.py
@@ -512,7 +512,7 @@ class Broker:
             worker.submit_workflow,
             key=request.request_uid,
             setup_code=request.request_body.get("setup_code", ""),
-            entry_point="cads_adaptors:DummyAdaptor",
+            entry_point=request.entry_point,
             config=dict(
                 request_uid=request.request_uid,
                 user_uid=request.user_uid,

--- a/cads_broker/dispatcher.py
+++ b/cads_broker/dispatcher.py
@@ -370,7 +370,8 @@ class Broker:
     @perf_logger
     def sync_qos_rules(self, session_write) -> None:
         qos_rules = db.get_qos_rules(session=session_write)
-        logger.info("performance", tasks_number=len(self.internal_scheduler.queue))
+        if tasks_number := len(self.internal_scheduler.queue):
+            logger.info("performance", tasks_number=tasks_number)
         for task in list(self.internal_scheduler.queue)[
             : int(os.getenv("BROKER_MAX_INTERNAL_SCHEDULER_TASKS", 500))
         ]:

--- a/cads_broker/dispatcher.py
+++ b/cads_broker/dispatcher.py
@@ -338,6 +338,11 @@ class Broker:
                         self.qos.notify_end_of_request(
                             request, session, scheduler=self.internal_scheduler
                         )
+                        logger.info(
+                            "job has finished",
+                            dask_status=task["state"],
+                            **db.logger_kwargs(request=request),
+                        )
                 elif state == "erred":
                     exception = pickle.loads(task["exception"])
                     self.set_request_error_status(
@@ -347,6 +352,11 @@ class Broker:
                     )
                     self.qos.notify_end_of_request(
                         request, session, scheduler=self.internal_scheduler
+                    )
+                    logger.info(
+                        "job has finished",
+                        dask_status=task["state"],
+                        **db.logger_kwargs(request=request),
                     )
             # if it doesn't find the request: re-queue it
             else:

--- a/cads_broker/dispatcher.py
+++ b/cads_broker/dispatcher.py
@@ -433,7 +433,7 @@ class Broker:
         for key in finished_futures:
             self.futures.pop(key, None)
 
-    def on_future_done(self, future: distributed.Future) -> None:
+    def on_future_done(self, future: distributed.Future) -> str:
         with self.session_maker_write() as session:
             request = db.get_request(future.key, session=session)
             if request.status != "running":
@@ -466,6 +466,7 @@ class Broker:
             else:
                 # if the dask status is cancelled, the qos has already been reset by sync_database
                 return
+            future.release()
             # self.futures.pop(future.key, None)
             if request:
                 self.qos.notify_end_of_request(

--- a/cads_broker/dispatcher.py
+++ b/cads_broker/dispatcher.py
@@ -242,6 +242,7 @@ class Broker:
     @property
     def number_of_workers(self):
         if self.client.scheduler is None:
+            logger.info("Reconnecting to dask scheduler...")
             self.client = distributed.Client(self.address)
         number_of_workers = get_number_of_workers(client=self.client)
         self.environment.number_of_workers = number_of_workers

--- a/cads_broker/dispatcher.py
+++ b/cads_broker/dispatcher.py
@@ -524,7 +524,6 @@ class Broker:
             metadata=request.request_metadata,
         )
         self.futures[request.request_uid] = future
-        # future.add_done_callback(self.on_future_done)
         logger.info(
             "submitted job to scheduler",
             **db.logger_kwargs(request=request),

--- a/cads_broker/dispatcher.py
+++ b/cads_broker/dispatcher.py
@@ -264,13 +264,9 @@ class Broker:
         statement = sa.select(db.SystemRequest).where(
             db.SystemRequest.status == "running"
         )
-        dask_tasks = get_tasks(self.client)
         for request in session.scalars(statement):
             # if request is in futures, go on
             if request.request_uid in self.futures:
-                continue
-            # if request is in the scheduler, go on
-            elif request.request_uid in dask_tasks:
                 continue
             # if it doesn't find the request: re-queue it
             else:

--- a/cads_broker/dispatcher.py
+++ b/cads_broker/dispatcher.py
@@ -520,7 +520,7 @@ class Broker:
             metadata=request.request_metadata,
         )
         self.futures[request.request_uid] = future
-        future.add_done_callback(self.on_future_done)
+        # future.add_done_callback(self.on_future_done)
         logger.info(
             "submitted job to scheduler",
             **db.logger_kwargs(request=request),

--- a/cads_broker/dispatcher.py
+++ b/cads_broker/dispatcher.py
@@ -472,7 +472,7 @@ class Broker:
                 **request.adaptor_properties.config,
             ),
             form=request.adaptor_properties.form,
-            request=request.request_body,
+            request=request.request_body.get("request", {}),
             resources=request.request_metadata.get("resources", {}),
             metadata=request.request_metadata,
         )

--- a/cads_broker/qos/QoS.py
+++ b/cads_broker/qos/QoS.py
@@ -100,7 +100,7 @@ class QoS:
         new_limits = []
         for limit in properties.limits:
             if limit.full(request):
-                limit.queue()
+                limit.queue(request.request_uid)
                 limits.append(limit)
                 if str(limit.__hash__()) not in [r.uid for r in request.qos_rules]:
                     new_limits.append(limit)

--- a/cads_broker/qos/QoS.py
+++ b/cads_broker/qos/QoS.py
@@ -303,6 +303,8 @@ class QoS:
         limits_list = []
         for limit in self.limits_for(request, session):
             limit.increment()
+            if limit.value > 99:
+                print(f"------------------------------limit is {limit.value}")
             limits_list.append(limit)
         scheduler.append(
             {

--- a/cads_broker/qos/QoS.py
+++ b/cads_broker/qos/QoS.py
@@ -100,6 +100,7 @@ class QoS:
         new_limits = []
         for limit in properties.limits:
             if limit.full(request):
+                limit.queue()
                 limits.append(limit)
                 if str(limit.__hash__()) not in [r.uid for r in request.qos_rules]:
                     new_limits.append(limit)
@@ -303,8 +304,6 @@ class QoS:
         limits_list = []
         for limit in self.limits_for(request, session):
             limit.increment()
-            if limit.value > 99:
-                print(f"------------------------------limit is {limit.value}")
             limits_list.append(limit)
         scheduler.append(
             {

--- a/cads_broker/qos/QoS.py
+++ b/cads_broker/qos/QoS.py
@@ -101,8 +101,8 @@ class QoS:
         for limit in properties.limits:
             if limit.full(request):
                 limits.append(limit)
-                # if str(limit.__hash__()) not in [r.uid for r in request.qos_rules]:
-                new_limits.append(limit)
+                if str(limit.__hash__()) not in [r.uid for r in request.qos_rules]:
+                    new_limits.append(limit)
         if len(new_limits):
             scheduler.append(
                 {

--- a/cads_broker/qos/QoS.py
+++ b/cads_broker/qos/QoS.py
@@ -90,7 +90,7 @@ class QoS:
         for request in database.get_running_requests(session=session):
             # Recompute the limits
             for limit in self.limits_for(request, session):
-                limit.increment()
+                limit.increment(request.request_uid)
 
     @locked
     def can_run(self, request, session, scheduler):
@@ -303,7 +303,7 @@ class QoS:
         """
         limits_list = []
         for limit in self.limits_for(request, session):
-            limit.increment()
+            limit.increment(request.request_uid)
             limits_list.append(limit)
         scheduler.append(
             {

--- a/cads_broker/qos/Rule.py
+++ b/cads_broker/qos/Rule.py
@@ -115,7 +115,8 @@ class Limit(QoSRule):
         self.queued = set()
 
     def increment(self, request_uid):
-        self.queued.remove(request_uid)
+        if request_uid in self.queued:
+            self.queued.remove(request_uid)
         self.value += 1
 
     def decrement(self):

--- a/cads_broker/qos/Rule.py
+++ b/cads_broker/qos/Rule.py
@@ -110,14 +110,21 @@ class Limit(QoSRule):
 
     def __init__(self, environment, info, condition, conclusion):
         super().__init__(environment, info, condition, conclusion)
+        # running requests
         self.value = 0
+        self.queued = 0
 
     def increment(self):
+        if self.queued > 0:
+            self.queued -= 1
         self.value += 1
 
     def decrement(self):
         if self.value > 0:
             self.value -= 1
+
+    def queue(self):
+        self.queued += 1
 
     def capacity(self, request):
         return self.evaluate(request)

--- a/cads_broker/qos/Rule.py
+++ b/cads_broker/qos/Rule.py
@@ -112,19 +112,18 @@ class Limit(QoSRule):
         super().__init__(environment, info, condition, conclusion)
         # running requests
         self.value = 0
-        self.queued = 0
+        self.queued = set()
 
-    def increment(self):
-        if self.queued > 0:
-            self.queued -= 1
+    def increment(self, request_uid):
+        self.queued.remove(request_uid)
         self.value += 1
 
     def decrement(self):
         if self.value > 0:
             self.value -= 1
 
-    def queue(self):
-        self.queued += 1
+    def queue(self, request_uid):
+        self.queued.add(request_uid)
 
     def capacity(self, request):
         return self.evaluate(request)

--- a/tests/test_20_dispatcher.py
+++ b/tests/test_20_dispatcher.py
@@ -3,7 +3,6 @@ import uuid
 from typing import Any
 
 import distributed
-import pytest
 import pytest_mock
 import sqlalchemy as sa
 


### PR DESCRIPTION
This PR fixes various bugs in the broker / QoS status:
* `queued` and `running` requests count for each QoS rule is computed in one place and dumped to the db at each broker step.
* `queued` requests in the `system_requests` table are now always referenced in the `system_request_qos_rule` table.
* The update of the `qos_rules` table now doesn't block the broker.
* The `futures` are now updated directly by the broker at each step. The `future.add_done_callback()` is not used anymore because it often leave successful requests behind. This should fix the long running requests bug we encountered in production.
* The `cache_id` is now set at worker level. The `successful` status is set in the broker.