### PR TITLE
fix: restrict download bucket creation to S3 URLs only

### DIFF
--- a/cads_broker/entry_points.py
+++ b/cads_broker/entry_points.py
@@ -318,9 +318,10 @@ def init_db(connection_string: Optional[str] = None, force: bool = False) -> Non
     }
     download_buckets: List[str] = object_storage.parse_data_volumes_config()
     for download_bucket in download_buckets:
-        object_storage.create_download_bucket(
-            download_bucket, object_storage_url, **storage_kws
-        )
+        if download_bucket.startswith("s3://"):
+            object_storage.create_download_bucket(
+                download_bucket, object_storage_url, **storage_kws
+            )
     print("successfully created the cache areas in the object storage.")
 
 


### PR DESCRIPTION
This simple change is based on the assumption that we may have multiple locations for staging data for the users. 
s3 is not the only option, we also have shared filesystems.
