### PR TITLE
Improve scheduler memory management

### DIFF
--- a/cads_broker/config.py
+++ b/cads_broker/config.py
@@ -50,6 +50,7 @@ class BrokerConfig(pydantic_settings.BaseSettings):
     )
     broker_get_workers_resources_cache_time: int = 60
     broker_clean_scheduler_memory_interval_seconds: int = 300
+    broker_request_prefix: str = "req"
 
 
 class SqlalchemySettings(pydantic_settings.BaseSettings):

--- a/cads_broker/config.py
+++ b/cads_broker/config.py
@@ -49,6 +49,7 @@ class BrokerConfig(pydantic_settings.BaseSettings):
         10  # max discrepancy of workers number before qos rules are reloaded
     )
     broker_get_workers_resources_cache_time: int = 60
+    broker_clean_scheduler_memory_interval_seconds: int = 300
 
 
 class SqlalchemySettings(pydantic_settings.BaseSettings):

--- a/cads_broker/config.py
+++ b/cads_broker/config.py
@@ -49,7 +49,7 @@ class BrokerConfig(pydantic_settings.BaseSettings):
         10  # max discrepancy of workers number before qos rules are reloaded
     )
     broker_get_workers_resources_cache_time: int = 60
-    broker_clean_scheduler_memory_interval_seconds: int = 300
+    broker_clean_scheduler_memory_interval_seconds: int = 60
     broker_request_prefix: str = "req"
 
 

--- a/cads_broker/dask_utils.py
+++ b/cads_broker/dask_utils.py
@@ -73,7 +73,14 @@ def clean_scheduler_memory_for_all_clients(
                 "Cleaning scheduler memory for client",
                 client_address=client_address,
             )
-            clean_scheduler_memory(client)
+            try:
+                clean_scheduler_memory(client)
+            except Exception as e:
+                logger.error(
+                    "Error while cleaning scheduler memory for client",
+                    client_address=client_address,
+                    error=str(e),
+                )
             logger.info(
                 "Finished cleaning scheduler memory for client",
                 client_address=client_address,

--- a/cads_broker/dask_utils.py
+++ b/cads_broker/dask_utils.py
@@ -3,6 +3,9 @@ import time
 from typing import Iterable
 
 import distributed
+import structlog
+
+logger: structlog.stdlib.BoundLogger = structlog.get_logger(__name__)
 
 
 class Schedulers:
@@ -26,9 +29,13 @@ class Schedulers:
         with self.lock:
             return self.clients.values()
 
-    def get_client_addresses(self) -> Iterable[str]:
+    def get_clients_addresses(self) -> Iterable[str]:
         with self.lock:
             return self.clients.keys()
+
+    def get_clients_items(self):
+        with self.lock:
+            return self.clients.items()
 
 
 def clean_scheduler_memory(client: distributed.Client):
@@ -52,8 +59,22 @@ def clean_scheduler_memory(client: distributed.Client):
     client.run_on_scheduler(flush_network_logs)
 
 
-def clean_scheduler_memory_for_all_clients(schedulers: Schedulers, timeout_seconds: int = 300):
+def clean_scheduler_memory_for_all_clients(
+    schedulers: Schedulers, timeout_seconds: int = 300
+):
+    logger.info(
+        "Starting periodic scheduler memory cleanup thread",
+        timeout_seconds=timeout_seconds,
+    )
     while True:
         time.sleep(timeout_seconds)
-        for client in schedulers.get_clients_list():
+        for client_address, client in schedulers.get_clients_items():
+            logger.info(
+                "Cleaning scheduler memory for client",
+                client_address=client_address,
+            )
             clean_scheduler_memory(client)
+            logger.info(
+                "Finished cleaning scheduler memory for client",
+                client_address=client_address,
+            )

--- a/cads_broker/dask_utils.py
+++ b/cads_broker/dask_utils.py
@@ -1,4 +1,6 @@
 import threading
+from typing import Iterable
+
 import distributed
 
 
@@ -7,25 +9,25 @@ class Schedulers:
         self.clients = {}
         self.lock = threading.Lock()
 
-    def add_client(self, client_id, client):
+    def add_client(self, client_id: str, client: distributed.Client) -> None:
         with self.lock:
             self.clients[client_id] = client
 
-    def pop_client(self, client_id):
+    def pop_client(self, client_id: str) -> distributed.Client | None:
         with self.lock:
             return self.clients.pop(client_id, None)
 
-    def get_client(self, client_id):
+    def get_client(self, client_id: str) -> distributed.Client | None:
         with self.lock:
             return self.clients.get(client_id)
 
-    def get_clients_list(self):
+    def get_clients_list(self) -> Iterable[distributed.Client]:
         with self.lock:
-            return list(self.clients.values())
+            return self.clients.values()
 
-    def get_client_addresses(self):
+    def get_client_addresses(self) -> Iterable[str]:
         with self.lock:
-            return list(self.clients.keys())
+            return self.clients.keys()
 
 
 def clean_scheduler_memory(client: distributed.Client):
@@ -34,6 +36,7 @@ def clean_scheduler_memory(client: distributed.Client):
 
     This prevents memory leaks from massive task payloads during high-throughput load tests.
     """
+
     def flush_network_logs(dask_scheduler):
         import gc
 
@@ -41,7 +44,7 @@ def clean_scheduler_memory(client: distributed.Client):
 
         # Find all active and dead network buffers
         for obj in gc.get_objects():
-            if isinstance(obj, BatchedSend) and hasattr(obj, 'recent_message_log'):
+            if isinstance(obj, BatchedSend) and hasattr(obj, "recent_message_log"):
                 # Empty the log to sever the task references
                 obj.recent_message_log.clear()
 

--- a/cads_broker/dask_utils.py
+++ b/cads_broker/dask_utils.py
@@ -35,15 +35,15 @@ def clean_scheduler_memory(client: distributed.Client):
     This prevents memory leaks from massive task payloads during high-throughput load tests.
     """
     def flush_network_logs(dask_scheduler):
-    import gc
+        import gc
 
-    from distributed.batched import BatchedSend
+        from distributed.batched import BatchedSend
 
-    # Find all active and dead network buffers
-    for obj in gc.get_objects():
-        if isinstance(obj, BatchedSend) and hasattr(obj, 'recent_message_log'):
-            # Empty the log to sever the task references
-            obj.recent_message_log.clear()
+        # Find all active and dead network buffers
+        for obj in gc.get_objects():
+            if isinstance(obj, BatchedSend) and hasattr(obj, 'recent_message_log'):
+                # Empty the log to sever the task references
+                obj.recent_message_log.clear()
 
     client.run_on_scheduler(flush_network_logs)
 

--- a/cads_broker/dask_utils.py
+++ b/cads_broker/dask_utils.py
@@ -117,7 +117,11 @@ def get_tasks_from_scheduler(client: distributed.Client) -> Any:
     try:
         return client.run_on_scheduler(get_tasks_on_scheduler)
     except (distributed.comm.core.CommClosedError, OSError) as e:
-        logger.error("Cannot connect to scheduler", scheduler_url=client.scheduler.address, error=str(e))
+        logger.error(
+            "Cannot connect to scheduler",
+            scheduler_url=client.scheduler.address,
+            error=str(e),
+        )
         return {}
 
 

--- a/cads_broker/dask_utils.py
+++ b/cads_broker/dask_utils.py
@@ -175,7 +175,7 @@ def clean_scheduler_memory(client: distributed.Client):
     """
     Safely flushes Dask's internal BatchedSend network logs.
 
-    This prevents memory leaks from massive task payloads during high-throughput load tests.
+    This prevents dask scheduler memory leaks.
     """
 
     def flush_network_logs(dask_scheduler):

--- a/cads_broker/dask_utils.py
+++ b/cads_broker/dask_utils.py
@@ -1,4 +1,5 @@
 import threading
+import time
 from typing import Iterable
 
 import distributed
@@ -51,6 +52,8 @@ def clean_scheduler_memory(client: distributed.Client):
     client.run_on_scheduler(flush_network_logs)
 
 
-def clean_scheduler_memory_for_all_clients(schedulers: Schedulers):
-    for client in schedulers.get_clients_list():
-        clean_scheduler_memory(client)
+def clean_scheduler_memory_for_all_clients(schedulers: Schedulers, timeout_seconds: int = 300):
+    while True:
+        time.sleep(timeout_seconds)
+        for client in schedulers.get_clients_list():
+            clean_scheduler_memory(client)

--- a/cads_broker/dask_utils.py
+++ b/cads_broker/dask_utils.py
@@ -70,8 +70,8 @@ def create_dask_client(scheduler_url):
     try:
         client = distributed.Client(scheduler_url, heartbeat_interval=1000)
         return client
-    except OSError:
-        logger.error("Cannot connect to scheduler", scheduler_url=scheduler_url)
+    except OSError as e:
+        logger.error("Cannot connect to scheduler", scheduler_url=scheduler_url, error=str(e))
         return
 
 
@@ -111,8 +111,8 @@ def get_tasks_from_scheduler(client: distributed.Client) -> Any:
 
     try:
         return client.run_on_scheduler(get_tasks_on_scheduler)
-    except (distributed.comm.core.CommClosedError, OSError):
-        logger.error("Cannot connect to scheduler")
+    except (distributed.comm.core.CommClosedError, OSError) as e:
+        logger.error("Cannot connect to scheduler", scheduler_url=client.scheduler.address, error=str(e))
         return {}
 
 
@@ -166,8 +166,8 @@ def cancel_jobs_on_scheduler(client: distributed.Client, job_ids: list[str]) -> 
 
     try:
         return client.run_on_scheduler(cancel_jobs, job_ids=job_ids)
-    except (distributed.comm.core.CommClosedError, OSError, AttributeError):
-        logger.error("Cannot connect to scheduler")
+    except (distributed.comm.core.CommClosedError, OSError, AttributeError) as e:
+        logger.error("Cannot connect to scheduler", scheduler_url=client.scheduler.address, error=str(e))
         return
 
 

--- a/cads_broker/dask_utils.py
+++ b/cads_broker/dask_utils.py
@@ -1,0 +1,53 @@
+import threading
+import distributed
+
+
+class Schedulers:
+    def __init__(self):
+        self.clients = {}
+        self.lock = threading.Lock()
+
+    def add_client(self, client_id, client):
+        with self.lock:
+            self.clients[client_id] = client
+
+    def pop_client(self, client_id):
+        with self.lock:
+            return self.clients.pop(client_id, None)
+
+    def get_client(self, client_id):
+        with self.lock:
+            return self.clients.get(client_id)
+
+    def get_clients_list(self):
+        with self.lock:
+            return list(self.clients.values())
+
+    def get_client_addresses(self):
+        with self.lock:
+            return list(self.clients.keys())
+
+
+def clean_scheduler_memory(client: distributed.Client):
+    """
+    Safely flushes Dask's internal BatchedSend network logs.
+
+    This prevents memory leaks from massive task payloads during high-throughput load tests.
+    """
+    def flush_network_logs(dask_scheduler):
+    import gc
+
+    from distributed.batched import BatchedSend
+
+    # Find all active and dead network buffers
+    for obj in gc.get_objects():
+        if isinstance(obj, BatchedSend) and hasattr(obj, 'recent_message_log'):
+            # Empty the log to sever the task references
+            obj.recent_message_log.clear()
+
+    client.run_on_scheduler(flush_network_logs)
+
+
+def clean_scheduler_memory_for_all_clients(schedulers: Schedulers):
+    for client in schedulers.get_clients_list():
+        clean_scheduler_memory(client)

--- a/cads_broker/dask_utils.py
+++ b/cads_broker/dask_utils.py
@@ -1,11 +1,18 @@
+import os
+import signal
 import threading
 import time
-from typing import Iterable
+from typing import Any, Iterable
 
+import cachetools
 import distributed
 import structlog
 
+from cads_broker import config, database
+
 logger: structlog.stdlib.BoundLogger = structlog.get_logger(__name__)
+
+CONFIG = config.BrokerConfig()
 
 
 class Schedulers:
@@ -36,6 +43,132 @@ class Schedulers:
     def get_clients_items(self):
         with self.lock:
             return self.clients.items()
+
+
+@cachetools.cached(  # type: ignore
+    cache=cachetools.TTLCache(
+        maxsize=1024, ttl=CONFIG.broker_get_number_of_workers_cache_time
+    ),
+    info=True,
+)
+def get_number_of_workers(client: distributed.Client) -> int:
+    workers = client.scheduler_info().get("workers", {})
+    number_of_workers = len(
+        [w for w in workers.values() if w.get("status", None) == "running"]
+    )
+    return number_of_workers
+
+
+def get_total_number_of_workers(clients: Iterable[distributed.Client]) -> int:
+    number_of_workers = 0
+    for client in clients:
+        number_of_workers += get_number_of_workers(client)
+    return number_of_workers
+
+
+def create_dask_client(scheduler_url):
+    try:
+        client = distributed.Client(scheduler_url, heartbeat_interval=1000)
+        return client
+    except OSError:
+        logger.error("Cannot connect to scheduler", scheduler_url=scheduler_url)
+        return
+
+
+@cachetools.cached(  # type: ignore
+    cache=cachetools.TTLCache(
+        maxsize=1024, ttl=CONFIG.broker_get_workers_resources_cache_time
+    ),
+    info=True,
+)
+def get_workers_resources(client: distributed.Client) -> list[str]:
+    workers_resources = []
+    for worker in client.scheduler_info().get("workers", {}).values():
+        workers_resources.extend(list(worker.get("resources", {}).keys()))
+    return workers_resources
+
+
+@cachetools.cached(  # type: ignore
+    cache=cachetools.TTLCache(
+        maxsize=1024, ttl=CONFIG.broker_get_tasks_from_scheduler_cache_time
+    ),
+    info=True,
+)
+def get_tasks_from_scheduler(client: distributed.Client) -> Any:
+    """Get the tasks from the scheduler.
+
+    This function is executed on the scheduler pod.
+    """
+
+    def get_tasks_on_scheduler(dask_scheduler: distributed.Scheduler) -> dict[str, Any]:
+        tasks = {}
+        for task_id, task in dask_scheduler.tasks.items():
+            tasks[task_id] = {
+                "state": task.state,
+                "exception": task.exception,
+            }
+        return tasks
+
+    try:
+        return client.run_on_scheduler(get_tasks_on_scheduler)
+    except (distributed.comm.core.CommClosedError, OSError):
+        logger.error("Cannot connect to scheduler")
+        return {}
+
+
+def kill_job_on_worker(
+    client: distributed.Client | None,
+    request_uid: str,
+    session: database.sa.orm.Session,
+) -> None:
+    """Kill the job on the worker."""
+    # loop on all the processes related to the request_uid
+    if client is None:
+        return
+    for worker_pid_event in database.get_worker_pid(request_uid, session=session):
+        pid = worker_pid_event["pid"]
+        worker_ip = worker_pid_event["worker"]
+        try:
+            client.run(
+                os.kill,
+                pid,
+                signal.SIGTERM,
+                workers=[worker_ip],
+                nanny=True,
+                on_error="ignore",
+            )
+            logger.info(
+                "killed job on worker", job_id=request_uid, pid=pid, worker_ip=worker_ip
+            )
+        except (KeyError, NameError):
+            logger.warning(
+                "worker not found", job_id=request_uid, pid=pid, worker_ip=worker_ip
+            )
+        except ProcessLookupError:
+            logger.warning(
+                "process not found", job_id=request_uid, pid=pid, worker_ip=worker_ip
+            )
+
+
+def cancel_jobs_on_scheduler(client: distributed.Client, job_ids: list[str]) -> None:
+    """Cancel jobs on the dask scheduler.
+
+    This function is executed on the scheduler pod. This just cancel the jobs on the scheduler.
+    See https://stackoverflow.com/questions/49203128/how-do-i-stop-a-running-task-in-dask.
+    """
+
+    def cancel_jobs(dask_scheduler: distributed.Scheduler, job_ids: list[str]) -> None:
+        for job_id in job_ids:
+            if job_id in dask_scheduler.tasks:
+                dask_scheduler.transitions(
+                    {job_id: "cancelled"}, stimulus_id="manual-cancel"
+                )
+
+    try:
+        return client.run_on_scheduler(cancel_jobs, job_ids=job_ids)
+    except (distributed.comm.core.CommClosedError, OSError, AttributeError):
+        logger.error("Cannot connect to scheduler")
+        return
 
 
 def clean_scheduler_memory(client: distributed.Client):

--- a/cads_broker/database.py
+++ b/cads_broker/database.py
@@ -671,7 +671,6 @@ def requeue_request(
     )
     request.request_metadata = metadata
     request.status = "accepted"
-    session.commit()
     logger.info("requeueing request", **logger_kwargs(request=request))
     return request
 
@@ -692,7 +691,6 @@ def set_successful_request(
     request = session.scalars(statement).one()
     request.status = "successful"
     request.finished_at = sa.func.now()
-    session.commit()
     return request
 
 
@@ -730,6 +728,7 @@ def set_request_status(
     resubmit: bool | None = None,
     priority: float | None = None,
     scheduler: str | None = None,
+    commit: bool = True,
 ) -> SystemRequest:
     """Set the status of a request."""
     statement = sa.select(SystemRequest).where(SystemRequest.request_uid == request_uid)
@@ -760,7 +759,8 @@ def set_request_status(
         request.cache_id = cache_id
     # FIXME: logs can't be live updated
     request.status = status
-    session.commit()
+    if commit:
+        session.commit()
     return request
 
 

--- a/cads_broker/database.py
+++ b/cads_broker/database.py
@@ -825,6 +825,14 @@ def ensure_adaptor_properties(
     session.commit()
 
 
+def get_worker_pid(request_uid: str, session: sa.orm.Session) -> list[dict[str, str]]:
+    """Get the worker pid for a request."""
+    events = get_events_from_request(
+        request_uid=request_uid, session=session, event_type="worker_pid"
+    )
+    return [json.loads(event.message) for event in events]
+
+
 def add_event(
     event_type: str,
     request_uid: str,

--- a/cads_broker/database.py
+++ b/cads_broker/database.py
@@ -690,7 +690,7 @@ def set_successful_request(
     statement = sa.select(SystemRequest).where(SystemRequest.request_uid == request_uid)
     request = session.scalars(statement).one()
     request.status = "successful"
-    request.finished_at = sa.func.now()
+    request.finished_at = datetime.datetime.now()
     return request
 
 
@@ -748,12 +748,12 @@ def set_request_status(
         metadata.update({"scheduler": scheduler})
         request.request_metadata = metadata
     if status == "successful":
-        request.finished_at = sa.func.now()
+        request.finished_at = datetime.datetime.now()
     elif status in ("failed", "rejected"):
-        request.finished_at = sa.func.now()
+        request.finished_at = datetime.datetime.now()
         request.response_error = {"message": error_message, "reason": error_reason}
     elif status == "running":
-        request.started_at = sa.func.now()
+        request.started_at = datetime.datetime.now()
         request.qos_status = {}
     if cache_id is not None:
         request.cache_id = cache_id

--- a/cads_broker/dispatcher.py
+++ b/cads_broker/dispatcher.py
@@ -812,7 +812,7 @@ class Broker:
         If the status of the request in the database is not "running", it does nothing and returns None.
         """
         with self.session_maker_write() as session:
-            request_uid = future.key.removeprefix("request-")
+            request_uid = future.key.removeprefix(f"{CONFIG.broker_request_prefix}-")
             try:
                 request = db.get_request(request_uid, session=session)
             except db.NoResultFound:
@@ -936,7 +936,7 @@ class Broker:
                 )
                 future = client.submit(
                     worker.submit_workflow,
-                    key="request-" + request.request_uid,
+                    key=f"{CONFIG.broker_request_prefix}-{request.request_uid}",
                     setup_code=request.request_body.get("setup_code", ""),
                     entry_point=request.entry_point,
                     config=dict(

--- a/cads_broker/dispatcher.py
+++ b/cads_broker/dispatcher.py
@@ -22,7 +22,7 @@ try:
 except ModuleNotFoundError:
     pass
 
-from cads_broker import Environment, config, factory
+from cads_broker import Environment, config, dask_utils, factory
 from cads_broker import database as db
 from cads_broker.qos import QoS
 
@@ -127,7 +127,9 @@ def get_tasks_from_scheduler(client: distributed.Client) -> Any:
         return {}
 
 
-def kill_job_on_worker(client: distributed.Client | None, request_uid: str, session: sa.orm.Session) -> None:
+def kill_job_on_worker(
+    client: distributed.Client | None, request_uid: str, session: sa.orm.Session
+) -> None:
     """Kill the job on the worker."""
     # loop on all the processes related to the request_uid
     if client is None:
@@ -441,7 +443,7 @@ def requeue_request(
 
 @attrs.define
 class Broker:
-    schedulers: dict[str, distributed.Client]
+    schedulers: dask_utils.Schedulers
     input_schedulers: list[str]
     environment: Environment.Environment
     qos: QoS.QoS
@@ -467,15 +469,15 @@ class Broker:
         session_maker_read: sa.orm.sessionmaker | None = None,
         session_maker_write: sa.orm.sessionmaker | None = None,
     ):
-        schedulers = {}
+        schedulers = dask_utils.Schedulers()
         for scheduler in scheduler_url:
             if (client := create_dask_client(scheduler)) is not None:
-                schedulers[scheduler] = client
+                schedulers.add_client(scheduler, client)
         session_maker_read = db.ensure_session_obj(session_maker_read, mode="r")
         session_maker_write = db.ensure_session_obj(session_maker_write, mode="w")
         with session_maker_read() as session_read:
             qos = instantiate_qos(
-                session_read, get_total_number_of_workers(schedulers.values())
+                session_read, get_total_number_of_workers(schedulers.get_clients_list())
             )
         with session_maker_write() as session:
             reload_qos_rules(session, qos)
@@ -491,7 +493,7 @@ class Broker:
 
     def set_number_of_workers(self):
         number_of_workers = get_total_number_of_workers(
-            clients=self.schedulers.values()
+            clients=self.schedulers.get_clients_list()
         )
         self.environment.number_of_workers = number_of_workers
         return number_of_workers
@@ -501,7 +503,7 @@ class Broker:
         if (
             abs(
                 self.environment.number_of_workers
-                - get_total_number_of_workers(self.schedulers.values())
+                - get_total_number_of_workers(self.schedulers.get_clients_list())
             )
             > CONFIG.broker_workers_gap
         ) or self.environment.number_of_workers == 0:
@@ -528,7 +530,9 @@ class Broker:
             return request
         requeue = CONFIG.broker_requeue_on_killed_worker_requests
         if error_reason == "KilledWorker":
-            client = self.schedulers.get(request.request_metadata.get("scheduler"))
+            client = self.schedulers.get_client(
+                request.request_metadata.get("scheduler")
+            )
             if client is None:
                 logger.warning(
                     "scheduler not found",
@@ -652,7 +656,9 @@ class Broker:
             session, limit=CONFIG.broker_max_dismissed_requests
         )
         for request in dismissed_requests:
-            client = self.schedulers.get(request.request_metadata.get("scheduler"))
+            client = self.schedulers.get_client(
+                request.request_metadata.get("scheduler")
+            )
             if future := self.futures.pop(request.request_uid, None):
                 future.cancel()
             else:
@@ -665,7 +671,7 @@ class Broker:
 
         # get all the tasks from the schedulers pool
         scheduler_tasks = {}
-        for client in self.schedulers.values():
+        for client in self.schedulers.get_clients_list():
             scheduler_tasks.update(get_tasks_from_scheduler(client))
 
         requests = db.get_running_requests(session=session)
@@ -908,10 +914,13 @@ class Broker:
         """Submit the request to the dask scheduler and update the qos rules accordingly."""
         # randomly shuffle the schedulers to balance the load based on the number of workers
         for scheduler in plackett_luce_shuffle(
-            self.schedulers.keys(),
-            [get_number_of_workers(client) for client in self.schedulers.values()],
+            self.schedulers.get_client_addresses(),
+            [
+                get_number_of_workers(client)
+                for client in self.schedulers.get_clients_list()
+            ],
         ):
-            client = self.schedulers[scheduler]
+            client = self.schedulers.get_client(scheduler)
             resources = request.request_metadata.get("resources", {})
             request.request_metadata["scheduler"] = scheduler
             # check if the resources are available on the workers pool
@@ -949,17 +958,23 @@ class Broker:
 
     def run(self) -> None:
         """Run the broker loop."""
+        cleanup_scheduler_memory_thread = threading.Thread(
+            target=dask_utils.clean_scheduler_memory_for_all_clients,
+            args=(self.schedulers, 300),
+            daemon=True,
+        )
+        cleanup_scheduler_memory_thread.start()
         while True:
             start_loop = time.perf_counter()
             # check if the scheduler is alive
             for scheduler in self.input_schedulers:
-                client = self.schedulers.get(scheduler)
+                client = self.schedulers.get_client(scheduler)
                 if client is None or client.scheduler is None:
                     logger.info(f"Reconnecting to dask scheduler {scheduler}")
                     if (client := create_dask_client(scheduler)) is not None:
-                        self.schedulers[scheduler] = client
+                        self.schedulers.add_client(scheduler, client)
                     else:
-                        self.schedulers.pop(scheduler, None)
+                        self.schedulers.pop_client(scheduler)
             # reset the cache of the qos functions
             db.QOS_FUNCTIONS_CACHE.clear()
             with self.session_maker_read() as session_read:
@@ -1007,7 +1022,7 @@ class Broker:
                     )
 
                 cancel_stuck_requests(
-                    clients=self.schedulers.values(), session=session_read
+                    clients=self.schedulers.get_clients_list(), session=session_read
                 )
                 running_requests = len(db.get_running_requests(session=session_read))
                 queue_length = self.queue.len()

--- a/cads_broker/dispatcher.py
+++ b/cads_broker/dispatcher.py
@@ -134,9 +134,7 @@ def kill_job_on_worker(
     # loop on all the processes related to the request_uid
     if client is None:
         return
-    # for worker_pid_event in client.get_events(request_uid):
     for worker_pid_event in db.get_worker_pid(request_uid, session=session):
-        # _, worker_pid_event = worker_pid_event
         pid = worker_pid_event["pid"]
         worker_ip = worker_pid_event["worker"]
         try:
@@ -554,7 +552,6 @@ class Broker:
             worker_restart_events = client.get_events("worker-restart-memory")
             # get info on worker and pid of the killed request
             try:
-                # worker_pid_event = client.get_events(request_uid)[0][1]
                 worker_pid_event = db.get_worker_pid(request_uid, session=session)[0]
             except IndexError:
                 worker_restart_events = False

--- a/cads_broker/dispatcher.py
+++ b/cads_broker/dispatcher.py
@@ -444,7 +444,7 @@ def requeue_request(
 @attrs.define
 class Broker:
     schedulers: dask_utils.Schedulers
-    input_schedulers: list[str]
+    schedulers_url: list[str]
     environment: Environment.Environment
     qos: QoS.QoS
     session_maker_read: sa.orm.sessionmaker
@@ -487,7 +487,7 @@ class Broker:
             session_maker_write=session_maker_write,
             environment=qos.environment,
             qos=qos,
-            input_schedulers=scheduler_url,
+            schedulers_url=scheduler_url,
         )
         return self
 
@@ -970,14 +970,14 @@ class Broker:
         while True:
             start_loop = time.perf_counter()
             # check if the scheduler is alive
-            for scheduler in self.input_schedulers:
-                client = self.schedulers.get_client(scheduler)
+            for scheduler_url in self.schedulers_url:
+                client = self.schedulers.get_client(scheduler_url)
                 if client is None or client.scheduler is None:
-                    logger.info(f"Reconnecting to dask scheduler {scheduler}")
-                    if (client := create_dask_client(scheduler)) is not None:
-                        self.schedulers.add_client(scheduler, client)
+                    logger.info(f"Reconnecting to dask scheduler {scheduler_url}")
+                    if (client := create_dask_client(scheduler_url)) is not None:
+                        self.schedulers.add_client(scheduler_url, client)
                     else:
-                        self.schedulers.pop_client(scheduler)
+                        self.schedulers.pop_client(scheduler_url)
             # reset the cache of the qos functions
             db.QOS_FUNCTIONS_CACHE.clear()
             with self.session_maker_read() as session_read:

--- a/cads_broker/dispatcher.py
+++ b/cads_broker/dispatcher.py
@@ -804,7 +804,7 @@ class Broker:
         If the status of the request in the database is not "running", it does nothing and returns None.
         """
         with self.session_maker_write() as session:
-            request_uid = future.key.strip("request-")
+            request_uid = future.key.removeprefix("request-")
             try:
                 request = db.get_request(request_uid, session=session)
             except db.NoResultFound:

--- a/cads_broker/dispatcher.py
+++ b/cads_broker/dispatcher.py
@@ -127,13 +127,14 @@ def get_tasks_from_scheduler(client: distributed.Client) -> Any:
         return {}
 
 
-def kill_job_on_worker(client: distributed.Client | None, request_uid: str) -> None:
+def kill_job_on_worker(client: distributed.Client | None, request_uid: str, session: sa.orm.Session) -> None:
     """Kill the job on the worker."""
     # loop on all the processes related to the request_uid
     if client is None:
         return
-    for worker_pid_event in client.get_events(request_uid):
-        _, worker_pid_event = worker_pid_event
+    # for worker_pid_event in client.get_events(request_uid):
+    for worker_pid_event in db.get_worker_pid(request_uid, session=session):
+        # _, worker_pid_event = worker_pid_event
         pid = worker_pid_event["pid"]
         worker_ip = worker_pid_event["worker"]
         try:
@@ -547,7 +548,8 @@ class Broker:
             worker_restart_events = client.get_events("worker-restart-memory")
             # get info on worker and pid of the killed request
             try:
-                worker_pid_event = client.get_events(request_uid)[0][1]
+                # worker_pid_event = client.get_events(request_uid)[0][1]
+                worker_pid_event = db.get_worker_pid(request_uid, session=session)[0]
             except IndexError:
                 worker_restart_events = False
                 requeue = True
@@ -657,7 +659,7 @@ class Broker:
                 # if the request is not in the futures, it means that the request has been lost by the broker
                 # try to cancel the job directly on the scheduler
                 cancel_jobs_on_scheduler(client, job_ids=[request.request_uid])
-            kill_job_on_worker(client, request.request_uid)
+            kill_job_on_worker(client, request.request_uid, session=session)
             session = self.manage_dismissed_request(request, session)
         session.commit()
 

--- a/cads_broker/dispatcher.py
+++ b/cads_broker/dispatcher.py
@@ -4,7 +4,6 @@ import io
 import os
 import pickle
 import random
-import signal
 import threading
 import time
 import traceback
@@ -44,49 +43,6 @@ CONFIG = config.BrokerConfig()
 
 
 @cachetools.cached(  # type: ignore
-    cache=cachetools.TTLCache(
-        maxsize=1024, ttl=CONFIG.broker_get_number_of_workers_cache_time
-    ),
-    info=True,
-)
-def get_number_of_workers(client: distributed.Client) -> int:
-    workers = client.scheduler_info().get("workers", {})
-    number_of_workers = len(
-        [w for w in workers.values() if w.get("status", None) == "running"]
-    )
-    return number_of_workers
-
-
-def get_total_number_of_workers(clients: Iterable[distributed.Client]) -> int:
-    number_of_workers = 0
-    for client in clients:
-        number_of_workers += get_number_of_workers(client)
-    return number_of_workers
-
-
-def create_dask_client(scheduler_url):
-    try:
-        client = distributed.Client(scheduler_url, heartbeat_interval=1000)
-        return client
-    except OSError:
-        logger.error("Cannot connect to scheduler", scheduler_url=scheduler_url)
-        return
-
-
-@cachetools.cached(  # type: ignore
-    cache=cachetools.TTLCache(
-        maxsize=1024, ttl=CONFIG.broker_get_workers_resources_cache_time
-    ),
-    info=True,
-)
-def get_workers_resources(client: distributed.Client) -> list[str]:
-    workers_resources = []
-    for worker in client.scheduler_info().get("workers", {}).values():
-        workers_resources.extend(list(worker.get("resources", {}).keys()))
-    return workers_resources
-
-
-@cachetools.cached(  # type: ignore
     cache=cachetools.TTLCache(maxsize=1024, ttl=CONFIG.broker_qos_rules_cache_time),
     info=True,
 )
@@ -97,89 +53,6 @@ def get_rules_hash(rules_path: str):
         with open(rules_path) as f:
             rules = f.read()
     return hashlib.md5(rules.encode()).hexdigest()
-
-
-@cachetools.cached(  # type: ignore
-    cache=cachetools.TTLCache(
-        maxsize=1024, ttl=CONFIG.broker_get_tasks_from_scheduler_cache_time
-    ),
-    info=True,
-)
-def get_tasks_from_scheduler(client: distributed.Client) -> Any:
-    """Get the tasks from the scheduler.
-
-    This function is executed on the scheduler pod.
-    """
-
-    def get_tasks_on_scheduler(dask_scheduler: distributed.Scheduler) -> dict[str, Any]:
-        tasks = {}
-        for task_id, task in dask_scheduler.tasks.items():
-            tasks[task_id] = {
-                "state": task.state,
-                "exception": task.exception,
-            }
-        return tasks
-
-    try:
-        return client.run_on_scheduler(get_tasks_on_scheduler)
-    except (distributed.comm.core.CommClosedError, OSError):
-        logger.error("Cannot connect to scheduler")
-        return {}
-
-
-def kill_job_on_worker(
-    client: distributed.Client | None, request_uid: str, session: sa.orm.Session
-) -> None:
-    """Kill the job on the worker."""
-    # loop on all the processes related to the request_uid
-    if client is None:
-        return
-    for worker_pid_event in db.get_worker_pid(request_uid, session=session):
-        pid = worker_pid_event["pid"]
-        worker_ip = worker_pid_event["worker"]
-        try:
-            client.run(
-                os.kill,
-                pid,
-                signal.SIGTERM,
-                workers=[worker_ip],
-                nanny=True,
-                on_error="ignore",
-            )
-            logger.info(
-                "killed job on worker", job_id=request_uid, pid=pid, worker_ip=worker_ip
-            )
-        except (KeyError, NameError):
-            logger.warning(
-                "worker not found", job_id=request_uid, pid=pid, worker_ip=worker_ip
-            )
-        except ProcessLookupError:
-            logger.warning(
-                "process not found", job_id=request_uid, pid=pid, worker_ip=worker_ip
-            )
-
-
-def cancel_jobs_on_scheduler(
-    client: distributed.Client | None, job_ids: list[str]
-) -> None:
-    """Cancel jobs on the dask scheduler.
-
-    This function is executed on the scheduler pod. This just cancel the jobs on the scheduler.
-    See https://stackoverflow.com/questions/49203128/how-do-i-stop-a-running-task-in-dask.
-    """
-
-    def cancel_jobs(dask_scheduler: distributed.Scheduler, job_ids: list[str]) -> None:
-        for job_id in job_ids:
-            if job_id in dask_scheduler.tasks:
-                dask_scheduler.transitions(
-                    {job_id: "cancelled"}, stimulus_id="manual-cancel"
-                )
-
-    try:
-        return client.run_on_scheduler(cancel_jobs, job_ids=job_ids)
-    except (distributed.comm.core.CommClosedError, OSError, AttributeError):
-        logger.error("Cannot connect to scheduler")
-        return
 
 
 @cachetools.cached(  # type: ignore
@@ -201,7 +74,7 @@ def cancel_stuck_requests(
                 f"canceling stuck requests for more than {CONFIG.broker_stuck_requests_limit_minutes} mins",
                 stuck_requests=stuck_requests,
             )
-            cancel_jobs_on_scheduler(client, job_ids=stuck_requests)
+            dask_utils.cancel_jobs_on_scheduler(client, job_ids=stuck_requests)
 
 
 class Scheduler:
@@ -471,13 +344,13 @@ class Broker:
     ):
         schedulers = dask_utils.Schedulers()
         for scheduler in scheduler_url:
-            if (client := create_dask_client(scheduler)) is not None:
+            if (client := dask_utils.create_dask_client(scheduler)) is not None:
                 schedulers.add_client(scheduler, client)
         session_maker_read = db.ensure_session_obj(session_maker_read, mode="r")
         session_maker_write = db.ensure_session_obj(session_maker_write, mode="w")
         with session_maker_read() as session_read:
             qos = instantiate_qos(
-                session_read, get_total_number_of_workers(schedulers.get_clients_list())
+                session_read, dask_utils.get_total_number_of_workers(schedulers.get_clients_list())
             )
         with session_maker_write() as session:
             reload_qos_rules(session, qos)
@@ -492,7 +365,7 @@ class Broker:
         return self
 
     def set_number_of_workers(self):
-        number_of_workers = get_total_number_of_workers(
+        number_of_workers = dask_utils.get_total_number_of_workers(
             clients=self.schedulers.get_clients_list()
         )
         self.environment.number_of_workers = number_of_workers
@@ -503,7 +376,7 @@ class Broker:
         if (
             abs(
                 self.environment.number_of_workers
-                - get_total_number_of_workers(self.schedulers.get_clients_list())
+                - dask_utils.get_total_number_of_workers(self.schedulers.get_clients_list())
             )
             > CONFIG.broker_workers_gap
         ) or self.environment.number_of_workers == 0:
@@ -666,15 +539,15 @@ class Broker:
             else:
                 # if the request is not in the futures, it means that the request has been lost by the broker
                 # try to cancel the job directly on the scheduler
-                cancel_jobs_on_scheduler(client, job_ids=[request.request_uid])
-            kill_job_on_worker(client, request.request_uid, session=session)
+                dask_utils.cancel_jobs_on_scheduler(client, job_ids=[request.request_uid])
+            dask_utils.kill_job_on_worker(client, request.request_uid, session=session)
             session = self.manage_dismissed_request(request, session)
         session.commit()
 
         # get all the tasks from the schedulers pool
         scheduler_tasks = {}
         for client in self.schedulers.get_clients_list():
-            scheduler_tasks.update(get_tasks_from_scheduler(client))
+            scheduler_tasks.update(dask_utils.get_tasks_from_scheduler(client))
 
         requests = db.get_running_requests(session=session)
         if len(scheduler_tasks) == 0 and len(self.futures):
@@ -920,7 +793,7 @@ class Broker:
         for scheduler in plackett_luce_shuffle(
             self.schedulers.get_clients_addresses(),
             [
-                get_number_of_workers(client)
+                dask_utils.get_number_of_workers(client)
                 for client in self.schedulers.get_clients_list()
             ],
         ):
@@ -928,7 +801,7 @@ class Broker:
             resources = request.request_metadata.get("resources", {})
             request.request_metadata["scheduler"] = scheduler
             # check if the resources are available on the workers pool
-            if set(resources.keys()).issubset(get_workers_resources(client)):
+            if set(resources.keys()).issubset(dask_utils.get_workers_resources(client)):
                 request = set_running_request(
                     request=request,
                     priority=priority,
@@ -975,7 +848,7 @@ class Broker:
                 client = self.schedulers.get_client(scheduler_url)
                 if client is None or client.scheduler is None:
                     logger.info(f"Reconnecting to dask scheduler {scheduler_url}")
-                    if (client := create_dask_client(scheduler_url)) is not None:
+                    if (client := dask_utils.create_dask_client(scheduler_url)) is not None:
                         self.schedulers.add_client(scheduler_url, client)
                     else:
                         self.schedulers.pop_client(scheduler_url)

--- a/cads_broker/dispatcher.py
+++ b/cads_broker/dispatcher.py
@@ -374,6 +374,7 @@ def set_running_request(
         priority=priority,
         scheduler=scheduler,
         session=session,
+        commit=False,
     )
     qos.notify_start_of_request(request, scheduler=internal_scheduler)
     queue.pop(request.request_uid)
@@ -416,6 +417,7 @@ def set_failed_request(
         error_message=error_message,
         error_reason=error_reason,
         session=session,
+        commit=False,
     )
     qos.notify_end_of_request(request, scheduler=internal_scheduler)
     logger.info(
@@ -570,12 +572,14 @@ class Broker:
                             message="Worker has been killed by the Nanny due to memory usage."
                             f"{job['worker']=}, {job['pid']=}, {job['rss']=}",
                             session=session,
+                            commit=False,
                         )
                         db.add_event(
                             event_type="user_visible_error",
                             request_uid=request_uid,
                             message=CONFIG.broker_memory_error_user_visible_log,
                             session=session,
+                            commit=False,
                         )
                         request = set_failed_request(
                             request=request,
@@ -757,6 +761,7 @@ class Broker:
                         internal_scheduler=self.internal_scheduler,
                         session=session,
                     )
+        session.commit()
 
     @perf_logger
     def sync_qos_rules(self, session_write) -> None:
@@ -791,7 +796,7 @@ class Broker:
                 qos_rules.update(new_qos_rules)
 
     @perf_logger
-    def sync_futures(self) -> None:
+    def sync_futures(self, session: sa.orm.Session) -> None:
         """Check if the futures are finished, error or cancelled and update the database accordingly.
 
         In a previous version of the broker used to call the client.add_done_callback method but
@@ -802,54 +807,54 @@ class Broker:
         finished_futures = []
         for future in self.futures.values():
             if future.status in ("finished", "error", "cancelled"):
-                finished_futures.append(self.on_future_done(future))
+                finished_futures.append(self.on_future_done(future, session))
+        session.commit()
         for key in finished_futures:
             self.futures.pop(key, None)
 
-    def on_future_done(self, future: distributed.Future) -> str | None:
+    def on_future_done(self, future: distributed.Future, session: sa.orm.Session) -> str | None:
         """Update the database status of the request according to the status of the future.
 
         If the status of the request in the database is not "running", it does nothing and returns None.
         """
-        with self.session_maker_write() as session:
-            request_uid = future.key.removeprefix(f"{CONFIG.broker_request_prefix}-")
-            try:
-                request = db.get_request(request_uid, session=session)
-            except db.NoResultFound:
-                logger.warning(
-                    "request not found",
-                    job_id=request_uid,
-                    dask_status=future.status,
-                )
-                return request_uid
-            if request.status != "running":
-                return None
-            if future.status == "finished":
-                # the result is updated in the database by the worker
-                set_successful_request(
-                    request=request,
-                    qos=self.qos,
-                    internal_scheduler=self.internal_scheduler,
-                    session=session,
-                )
-            elif future.status == "error":
-                exception = future.exception()
-                self.set_request_error_status(
-                    exception=exception, request_uid=request_uid, session=session
-                )
-            elif future.status != "cancelled":
-                # if the dask status is unknown, re-queue it
-                requeue_request(
-                    request=request,
-                    qos=self.qos,
-                    queue=self.queue,
-                    internal_scheduler=self.internal_scheduler,
-                    session=session,
-                )
-            else:
-                # if the dask status is cancelled, the qos has already been reset by sync_database
-                return None
-            future.release()
+        request_uid = future.key.removeprefix(f"{CONFIG.broker_request_prefix}-")
+        try:
+            request = db.get_request(request_uid, session=session)
+        except db.NoResultFound:
+            logger.warning(
+                "request not found",
+                job_id=request_uid,
+                dask_status=future.status,
+            )
+            return request_uid
+        if request.status != "running":
+            return None
+        if future.status == "finished":
+            # the result is updated in the database by the worker
+            set_successful_request(
+                request=request,
+                qos=self.qos,
+                internal_scheduler=self.internal_scheduler,
+                session=session,
+            )
+        elif future.status == "error":
+            exception = future.exception()
+            self.set_request_error_status(
+                exception=exception, request_uid=request_uid, session=session
+            )
+        elif future.status != "cancelled":
+            # if the dask status is unknown, re-queue it
+            requeue_request(
+                request=request,
+                qos=self.qos,
+                queue=self.queue,
+                internal_scheduler=self.internal_scheduler,
+                session=session,
+            )
+        else:
+            # if the dask status is cancelled, the qos has already been reset by sync_database
+            return None
+        future.release()
         return request_uid
 
     @perf_logger
@@ -904,6 +909,7 @@ class Broker:
                         priority=self.qos.priority(request),
                     )
                 requests_counter += 1
+        session_write.commit()
 
     def submit_request(
         self,
@@ -1001,7 +1007,7 @@ class Broker:
                         )
                     )
                     self.sync_qos_rules(session_write)
-                    self.sync_futures()
+                    self.sync_futures(session_write)
                     self.sync_database(session=session_write)
                     session_write.commit()
                     if (queue_length := self.queue.len()) != (

--- a/cads_broker/dispatcher.py
+++ b/cads_broker/dispatcher.py
@@ -804,15 +804,16 @@ class Broker:
         If the status of the request in the database is not "running", it does nothing and returns None.
         """
         with self.session_maker_write() as session:
+            request_uid = future.key.strip("request-")
             try:
-                request = db.get_request(future.key, session=session)
+                request = db.get_request(request_uid, session=session)
             except db.NoResultFound:
                 logger.warning(
                     "request not found",
-                    job_id=future.key,
+                    job_id=request_uid,
                     dask_status=future.status,
                 )
-                return future.key
+                return request_uid
             if request.status != "running":
                 return None
             if future.status == "finished":
@@ -826,7 +827,7 @@ class Broker:
             elif future.status == "error":
                 exception = future.exception()
                 self.set_request_error_status(
-                    exception=exception, request_uid=future.key, session=session
+                    exception=exception, request_uid=request_uid, session=session
                 )
             elif future.status != "cancelled":
                 # if the dask status is unknown, re-queue it
@@ -841,7 +842,7 @@ class Broker:
                 # if the dask status is cancelled, the qos has already been reset by sync_database
                 return None
             future.release()
-        return future.key
+        return request_uid
 
     @perf_logger
     def cache_requests_qos_properties(self, requests, session: sa.orm.Session) -> None:
@@ -924,7 +925,7 @@ class Broker:
                 )
                 future = client.submit(
                     worker.submit_workflow,
-                    key=request.request_uid,
+                    key="request-" + request.request_uid,
                     setup_code=request.request_body.get("setup_code", ""),
                     entry_point=request.entry_point,
                     config=dict(

--- a/cads_broker/dispatcher.py
+++ b/cads_broker/dispatcher.py
@@ -914,7 +914,7 @@ class Broker:
         """Submit the request to the dask scheduler and update the qos rules accordingly."""
         # randomly shuffle the schedulers to balance the load based on the number of workers
         for scheduler in plackett_luce_shuffle(
-            self.schedulers.get_client_addresses(),
+            self.schedulers.get_clients_addresses(),
             [
                 get_number_of_workers(client)
                 for client in self.schedulers.get_clients_list()
@@ -960,7 +960,7 @@ class Broker:
         """Run the broker loop."""
         cleanup_scheduler_memory_thread = threading.Thread(
             target=dask_utils.clean_scheduler_memory_for_all_clients,
-            args=(self.schedulers, 300),
+            args=(self.schedulers, CONFIG.broker_clean_scheduler_memory_interval_seconds),
             daemon=True,
         )
         cleanup_scheduler_memory_thread.start()

--- a/cads_broker/dispatcher.py
+++ b/cads_broker/dispatcher.py
@@ -350,7 +350,8 @@ class Broker:
         session_maker_write = db.ensure_session_obj(session_maker_write, mode="w")
         with session_maker_read() as session_read:
             qos = instantiate_qos(
-                session_read, dask_utils.get_total_number_of_workers(schedulers.get_clients_list())
+                session_read,
+                dask_utils.get_total_number_of_workers(schedulers.get_clients_list()),
             )
         with session_maker_write() as session:
             reload_qos_rules(session, qos)
@@ -376,7 +377,9 @@ class Broker:
         if (
             abs(
                 self.environment.number_of_workers
-                - dask_utils.get_total_number_of_workers(self.schedulers.get_clients_list())
+                - dask_utils.get_total_number_of_workers(
+                    self.schedulers.get_clients_list()
+                )
             )
             > CONFIG.broker_workers_gap
         ) or self.environment.number_of_workers == 0:
@@ -392,7 +395,7 @@ class Broker:
         """Set the status of the request to failed and write the error message and reason.
 
         If the error reason is "KilledWorker":
-            - if the worker has been killed by the Nanny for memory usage, it adds the message to the user 
+            - if the worker has been killed by the Nanny for memory usage, it adds the message to the user
               in the event table
             - if the worker is killed for unknown reasons, it re-queues the request if the requeue limit is
               not reached. This is configurable with the environment variable
@@ -539,7 +542,9 @@ class Broker:
             else:
                 # if the request is not in the futures, it means that the request has been lost by the broker
                 # try to cancel the job directly on the scheduler
-                dask_utils.cancel_jobs_on_scheduler(client, job_ids=[request.request_uid])
+                dask_utils.cancel_jobs_on_scheduler(
+                    client, job_ids=[request.request_uid]
+                )
             dask_utils.kill_job_on_worker(client, request.request_uid, session=session)
             session = self.manage_dismissed_request(request, session)
         session.commit()
@@ -678,7 +683,9 @@ class Broker:
         for key in finished_futures:
             self.futures.pop(key, None)
 
-    def on_future_done(self, future: distributed.Future, session: sa.orm.Session) -> str | None:
+    def on_future_done(
+        self, future: distributed.Future, session: sa.orm.Session
+    ) -> str | None:
         """Update the database status of the request according to the status of the future.
 
         If the status of the request in the database is not "running", it does nothing and returns None.
@@ -832,7 +839,10 @@ class Broker:
         """Run the broker loop."""
         cleanup_scheduler_memory_thread = threading.Thread(
             target=dask_utils.clean_scheduler_memory_for_all_clients,
-            args=(self.schedulers, CONFIG.broker_clean_scheduler_memory_interval_seconds),
+            args=(
+                self.schedulers,
+                CONFIG.broker_clean_scheduler_memory_interval_seconds,
+            ),
             daemon=True,
         )
         cleanup_scheduler_memory_thread.start()
@@ -843,7 +853,9 @@ class Broker:
                 client = self.schedulers.get_client(scheduler_url)
                 if client is None or client.scheduler is None:
                     logger.info(f"Reconnecting to dask scheduler {scheduler_url}")
-                    if (client := dask_utils.create_dask_client(scheduler_url)) is not None:
+                    if (
+                        client := dask_utils.create_dask_client(scheduler_url)
+                    ) is not None:
                         self.schedulers.add_client(scheduler_url, client)
                     else:
                         self.schedulers.pop_client(scheduler_url)

--- a/cads_broker/dispatcher.py
+++ b/cads_broker/dispatcher.py
@@ -519,9 +519,10 @@ class Broker:
         """Set the status of the request to failed and write the error message and reason.
 
         If the error reason is "KilledWorker":
-            - if the worker has been killed by the Nanny for memory usage, it add the event for the user
-            - if the worker is killed for unknown reasons, it re-queues the request
-              if the requeue limit is not reached. This is configurable with the environment variable
+            - if the worker has been killed by the Nanny for memory usage, it adds the message to the user 
+              in the event table
+            - if the worker is killed for unknown reasons, it re-queues the request if the requeue limit is
+              not reached. This is configurable with the environment variable
         """
         error_message = "".join(traceback.format_exception(exception))
         error_reason = exception.__class__.__name__

--- a/tests/test_04_dask_utils.py
+++ b/tests/test_04_dask_utils.py
@@ -1,0 +1,528 @@
+"""Unit tests for the dask_utils module."""
+
+import threading
+from unittest.mock import Mock, patch
+
+import pytest
+from distributed import Client, comm
+
+from cads_broker import dask_utils
+
+
+def test_add_client() -> None:
+    """Test adding a client to the schedulers dict."""
+    schedulers = dask_utils.Schedulers()
+    mock_client = Mock(spec=Client)
+
+    schedulers.add_client("client_1", mock_client)
+
+    retrieved_client = schedulers.get_client("client_1")
+    assert retrieved_client is mock_client
+
+def test_pop_client() -> None:
+    """Test popping a client from the schedulers dict."""
+    schedulers = dask_utils.Schedulers()
+    mock_client = Mock(spec=Client)
+    schedulers.add_client("client_1", mock_client)
+
+    popped_client = schedulers.pop_client("client_1")
+
+    assert popped_client is mock_client
+    assert schedulers.get_client("client_1") is None
+
+def test_pop_client_not_found() -> None:
+    """Test popping a non-existent client returns None."""
+    schedulers = dask_utils.Schedulers()
+
+    popped_client = schedulers.pop_client("non_existent")
+
+    assert popped_client is None
+
+def test_get_client() -> None:
+    """Test getting a client from the schedulers dict."""
+    schedulers = dask_utils.Schedulers()
+    mock_client = Mock(spec=Client)
+    schedulers.add_client("client_1", mock_client)
+
+    retrieved_client = schedulers.get_client("client_1")
+
+    assert retrieved_client is mock_client
+
+def test_get_client_not_found() -> None:
+    """Test getting a non-existent client returns None."""
+    schedulers = dask_utils.Schedulers()
+
+    retrieved_client = schedulers.get_client("non_existent")
+
+    assert retrieved_client is None
+
+def test_get_clients_list() -> None:
+    """Test getting all clients as a list."""
+    schedulers = dask_utils.Schedulers()
+    mock_client_1 = Mock(spec=Client)
+    mock_client_2 = Mock(spec=Client)
+    schedulers.add_client("client_1", mock_client_1)
+    schedulers.add_client("client_2", mock_client_2)
+
+    clients = list(schedulers.get_clients_list())
+
+    assert len(clients) == 2
+    assert mock_client_1 in clients
+    assert mock_client_2 in clients
+
+def test_get_clients_addresses() -> None:
+    """Test getting all client addresses (keys)."""
+    schedulers = dask_utils.Schedulers()
+    mock_client_1 = Mock(spec=Client)
+    mock_client_2 = Mock(spec=Client)
+    schedulers.add_client("client_1", mock_client_1)
+    schedulers.add_client("client_2", mock_client_2)
+
+    addresses = list(schedulers.get_clients_addresses())
+
+    assert len(addresses) == 2
+    assert "client_1" in addresses
+    assert "client_2" in addresses
+
+def test_get_clients_items() -> None:
+    """Test getting all client items."""
+    schedulers = dask_utils.Schedulers()
+    mock_client_1 = Mock(spec=Client)
+    mock_client_2 = Mock(spec=Client)
+    schedulers.add_client("client_1", mock_client_1)
+    schedulers.add_client("client_2", mock_client_2)
+
+    items = list(schedulers.get_clients_items())
+
+    assert len(items) == 2
+    assert ("client_1", mock_client_1) in items
+    assert ("client_2", mock_client_2) in items
+
+def test_thread_safety() -> None:
+    """Test thread safety of Schedulers class."""
+    schedulers = dask_utils.Schedulers()
+    mock_clients = [Mock(spec=Client) for _ in range(10)]
+    results = []
+
+    def add_clients():
+        for i, client in enumerate(mock_clients):
+            schedulers.add_client(f"client_{i}", client)
+
+    def get_clients():
+        for i in range(len(mock_clients)):
+            client = schedulers.get_client(f"client_{i}")
+            if client:
+                results.append(client)
+
+    threads = [
+        threading.Thread(target=add_clients),
+        threading.Thread(target=get_clients),
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert len(schedulers.get_clients_list()) == 10
+
+
+def test_get_number_of_workers_all_running() -> None:
+    """Test getting number of running workers."""
+    mock_client = Mock(spec=Client)
+    mock_client.scheduler_info.return_value = {
+        "workers": {
+            "worker_1": {"status": "running"},
+            "worker_2": {"status": "running"},
+            "worker_3": {"status": "running"},
+        }
+    }
+
+    # Clear cache before test
+    dask_utils.get_number_of_workers.cache_clear()
+
+    result = dask_utils.get_number_of_workers(mock_client)
+
+    assert result == 3
+
+def test_get_number_of_workers_mixed_statuses() -> None:
+    """Test getting number of workers with mixed statuses."""
+    mock_client = Mock(spec=Client)
+    mock_client.scheduler_info.return_value = {
+        "workers": {
+            "worker_1": {"status": "running"},
+            "worker_2": {"status": "idle"},
+            "worker_3": {"status": "running"},
+            "worker_4": {"status": "closed"},
+        }
+    }
+
+    # Clear cache before test
+    dask_utils.get_number_of_workers.cache_clear()
+
+    result = dask_utils.get_number_of_workers(mock_client)
+
+    assert result == 2
+
+def test_get_number_of_workers_no_workers() -> None:
+    """Test getting number of workers when no workers are available."""
+    mock_client = Mock(spec=Client)
+    mock_client.scheduler_info.return_value = {"workers": {}}
+
+    # Clear cache before test
+    dask_utils.get_number_of_workers.cache_clear()
+
+    result = dask_utils.get_number_of_workers(mock_client)
+
+    assert result == 0
+
+def test_get_number_of_workers_no_status() -> None:
+    """Test getting number of workers when status is missing."""
+    mock_client = Mock(spec=Client)
+    mock_client.scheduler_info.return_value = {
+        "workers": {
+            "worker_1": {},
+            "worker_2": {"status": "running"},
+        }
+    }
+
+    # Clear cache before test
+    dask_utils.get_number_of_workers.cache_clear()
+
+    result = dask_utils.get_number_of_workers(mock_client)
+
+    assert result == 1
+
+
+def test_get_total_number_of_workers() -> None:
+    """Test getting total number of workers across multiple clients."""
+    mock_client_1 = Mock(spec=Client)
+    mock_client_1.scheduler_info.return_value = {
+        "workers": {
+            "worker_1": {"status": "running"},
+            "worker_2": {"status": "running"},
+        }
+    }
+
+    mock_client_2 = Mock(spec=Client)
+    mock_client_2.scheduler_info.return_value = {
+        "workers": {
+            "worker_3": {"status": "running"},
+            "worker_4": {"status": "idle"},
+        }
+    }
+
+    # Clear cache before test
+    dask_utils.get_number_of_workers.cache_clear()
+
+    result = dask_utils.get_total_number_of_workers([mock_client_1, mock_client_2])
+
+    assert result == 3
+
+def test_get_total_number_of_workers_empty_list() -> None:
+    """Test getting total number of workers with no clients."""
+    # Clear cache before test
+    dask_utils.get_number_of_workers.cache_clear()
+
+    result = dask_utils.get_total_number_of_workers([])
+
+    assert result == 0
+
+
+def test_create_dask_client_success() -> None:
+    """Test successful creation of a dask client."""
+    with patch("distributed.Client") as mock_client_class:
+        mock_client_instance = Mock(spec=Client)
+        mock_client_class.return_value = mock_client_instance
+
+        result = dask_utils.create_dask_client("tcp://scheduler:8786")
+
+        mock_client_class.assert_called_once_with(
+            "tcp://scheduler:8786", heartbeat_interval=1000
+        )
+        assert result is mock_client_instance
+
+def test_create_dask_client_oserror(mocker) -> None:
+    """Test create_dask_client logs error on OSError."""
+    mock_logger = mocker.patch("cads_broker.dask_utils.logger")
+
+    with patch("distributed.Client") as mock_client_class:
+        mock_client_class.side_effect = OSError("Connection refused")
+
+        result = dask_utils.create_dask_client("tcp://invalid:8786")
+
+        assert result is None
+        mock_logger.error.assert_called_once()
+        call_kwargs = mock_logger.error.call_args[1]
+        assert "scheduler_url" in call_kwargs
+        assert "tcp://invalid:8786" in call_kwargs.values()
+
+
+def test_get_workers_resources() -> None:
+    """Test getting workers resources."""
+    mock_client = Mock(spec=Client)
+    mock_client.scheduler_info.return_value = {
+        "workers": {
+            "worker_1": {"resources": {"gpu": 1}},
+            "worker_2": {"resources": {"cpu": 4, "memory": 8}},
+            "worker_3": {"resources": {}},
+        }
+    }
+
+    # Clear cache before test
+    dask_utils.get_workers_resources.cache_clear()
+
+    result = dask_utils.get_workers_resources(mock_client)
+
+    assert "gpu" in result
+    assert "cpu" in result
+    assert "memory" in result
+    assert len(result) == 3
+
+def test_get_workers_resources_no_workers() -> None:
+    """Test getting workers resources when no workers are available."""
+    mock_client = Mock(spec=Client)
+    mock_client.scheduler_info.return_value = {"workers": {}}
+
+    # Clear cache before test
+    dask_utils.get_workers_resources.cache_clear()
+
+    result = dask_utils.get_workers_resources(mock_client)
+
+    assert result == []
+
+def test_get_workers_resources_no_resources() -> None:
+    """Test getting workers resources when workers have no resources."""
+    mock_client = Mock(spec=Client)
+    mock_client.scheduler_info.return_value = {
+        "workers": {
+            "worker_1": {},
+            "worker_2": {"resources": {"gpu": 1}},
+        }
+    }
+
+    # Clear cache before test
+    dask_utils.get_workers_resources.cache_clear()
+
+    result = dask_utils.get_workers_resources(mock_client)
+
+    assert "gpu" in result
+    assert len(result) == 1
+
+
+def test_get_tasks_from_scheduler_success() -> None:
+    """Test successfully getting tasks from scheduler."""
+    mock_client = Mock(spec=Client)
+    expected_tasks = {
+        "task_1": {"state": "running", "exception": None},
+        "task_2": {"state": "pending", "exception": None},
+    }
+    mock_client.run_on_scheduler.return_value = expected_tasks
+
+    # Clear cache before test
+    dask_utils.get_tasks_from_scheduler.cache_clear()
+
+    result = dask_utils.get_tasks_from_scheduler(mock_client)
+
+    assert result == expected_tasks
+
+def test_get_tasks_from_scheduler_commclosed_error(mocker) -> None:
+    """Test get_tasks_from_scheduler handles CommClosedError."""
+    mock_logger = mocker.patch("cads_broker.dask_utils.logger")
+    mock_client = Mock(spec=Client)
+    mock_client.scheduler = Mock()
+    mock_client.scheduler.address = "tcp://scheduler:8786"
+    mock_client.run_on_scheduler.side_effect = comm.core.CommClosedError(
+        "Connection closed"
+    )
+
+    # Clear cache before test
+    dask_utils.get_tasks_from_scheduler.cache_clear()
+
+    result = dask_utils.get_tasks_from_scheduler(mock_client)
+
+    assert result == {}
+    mock_logger.error.assert_called_once()
+
+def test_get_tasks_from_scheduler_oserror(mocker) -> None:
+    """Test get_tasks_from_scheduler handles OSError."""
+    mock_logger = mocker.patch("cads_broker.dask_utils.logger")
+    mock_client = Mock(spec=Client)
+    mock_client.scheduler = Mock()
+    mock_client.scheduler.address = "tcp://scheduler:8786"
+    mock_client.run_on_scheduler.side_effect = OSError("Connection refused")
+
+    # Clear cache before test
+    dask_utils.get_tasks_from_scheduler.cache_clear()
+
+    result = dask_utils.get_tasks_from_scheduler(mock_client)
+
+    assert result == {}
+    mock_logger.error.assert_called_once()
+
+
+def test_kill_job_on_worker_no_client(mocker) -> None:
+    """Test kill_job_on_worker when client is None."""
+    mock_session = Mock()
+
+    # Should not raise any error
+    dask_utils.kill_job_on_worker(None, "request_123", mock_session)
+
+def test_kill_job_on_worker_success(mocker) -> None:
+    """Test successfully killing a job on worker."""
+    mock_logger = mocker.patch("cads_broker.dask_utils.logger")
+    mock_session = Mock()
+    mock_database_get_worker_pid = mocker.patch(
+        "cads_broker.database.get_worker_pid"
+    )
+    mock_client = Mock(spec=Client)
+
+    mock_database_get_worker_pid.return_value = [
+        {"pid": 12345, "worker": "worker_1"},
+        {"pid": 12346, "worker": "worker_2"},
+    ]
+
+    dask_utils.kill_job_on_worker(mock_client, "request_123", mock_session)
+
+    assert mock_client.run.call_count == 2
+    mock_logger.info.assert_called()
+
+def test_kill_job_on_worker_keyerror(mocker) -> None:
+    """Test kill_job_on_worker handles KeyError."""
+    mock_logger = mocker.patch("cads_broker.dask_utils.logger")
+    mock_session = Mock()
+    mock_database_get_worker_pid = mocker.patch(
+        "cads_broker.database.get_worker_pid"
+    )
+    mock_client = Mock(spec=Client)
+
+    mock_database_get_worker_pid.return_value = [
+        {"pid": 12345, "worker": "worker_1"},
+    ]
+    mock_client.run.side_effect = KeyError("Worker not found")
+
+    dask_utils.kill_job_on_worker(mock_client, "request_123", mock_session)
+
+    mock_logger.warning.assert_called()
+
+def test_kill_job_on_worker_process_lookup_error(mocker) -> None:
+    """Test kill_job_on_worker handles ProcessLookupError."""
+    mock_logger = mocker.patch("cads_broker.dask_utils.logger")
+    mock_session = Mock()
+    mock_database_get_worker_pid = mocker.patch(
+        "cads_broker.database.get_worker_pid"
+    )
+    mock_client = Mock(spec=Client)
+
+    mock_database_get_worker_pid.return_value = [
+        {"pid": 12345, "worker": "worker_1"},
+    ]
+    mock_client.run.side_effect = ProcessLookupError("Process not found")
+
+    dask_utils.kill_job_on_worker(mock_client, "request_123", mock_session)
+
+    mock_logger.warning.assert_called()
+
+
+def test_cancel_jobs_on_scheduler_success() -> None:
+    """Test successfully canceling jobs on scheduler."""
+    mock_client = Mock(spec=Client)
+    job_ids = ["job_1", "job_2"]
+
+    dask_utils.cancel_jobs_on_scheduler(mock_client, job_ids)
+
+    mock_client.run_on_scheduler.assert_called_once()
+    call_kwargs = mock_client.run_on_scheduler.call_args[1]
+    assert call_kwargs["job_ids"] == job_ids
+
+def test_cancel_jobs_on_scheduler_commclosed_error(mocker) -> None:
+    """Test cancel_jobs_on_scheduler handles CommClosedError."""
+    mock_logger = mocker.patch("cads_broker.dask_utils.logger")
+    mock_client = Mock(spec=Client)
+    job_ids = ["job_1"]
+
+    mock_client.run_on_scheduler.side_effect = comm.core.CommClosedError(
+        "Connection closed"
+    )
+
+    dask_utils.cancel_jobs_on_scheduler(mock_client, job_ids)
+
+    mock_logger.error.assert_called_once()
+
+def test_cancel_jobs_on_scheduler_oserror(mocker) -> None:
+    """Test cancel_jobs_on_scheduler handles OSError."""
+    mock_logger = mocker.patch("cads_broker.dask_utils.logger")
+    mock_client = Mock(spec=Client)
+    job_ids = ["job_1"]
+
+    mock_client.run_on_scheduler.side_effect = OSError("Connection refused")
+
+    dask_utils.cancel_jobs_on_scheduler(mock_client, job_ids)
+
+    mock_logger.error.assert_called_once()
+
+def test_cancel_jobs_on_scheduler_attribute_error(mocker) -> None:
+    """Test cancel_jobs_on_scheduler handles AttributeError."""
+    mock_logger = mocker.patch("cads_broker.dask_utils.logger")
+    mock_client = Mock(spec=Client)
+    job_ids = ["job_1"]
+
+    mock_client.run_on_scheduler.side_effect = AttributeError("Attribute not found")
+
+    dask_utils.cancel_jobs_on_scheduler(mock_client, job_ids)
+
+    mock_logger.error.assert_called_once()
+
+
+def test_clean_scheduler_memory() -> None:
+    """Test cleaning scheduler memory."""
+    mock_client = Mock(spec=Client)
+
+    dask_utils.clean_scheduler_memory(mock_client)
+
+    mock_client.run_on_scheduler.assert_called_once()
+
+
+def test_clean_scheduler_memory_for_all_clients(mocker) -> None:
+    """Test cleaning scheduler memory for all clients."""
+    mocker.patch("cads_broker.dask_utils.logger")
+    mock_sleep = mocker.patch("time.sleep")
+    mock_clean = mocker.patch("cads_broker.dask_utils.clean_scheduler_memory")
+
+    mock_client_1 = Mock(spec=Client)
+    mock_client_2 = Mock(spec=Client)
+
+    schedulers = dask_utils.Schedulers()
+    schedulers.add_client("client_1", mock_client_1)
+    schedulers.add_client("client_2", mock_client_2)
+
+    # Simulate the function running and then stopping after the first iteration
+    mock_sleep.side_effect = [None, KeyboardInterrupt()]
+
+    with pytest.raises(KeyboardInterrupt):
+        dask_utils.clean_scheduler_memory_for_all_clients(schedulers, timeout_seconds=60)
+
+    # Check that sleep was called with the correct timeout
+    mock_sleep.assert_called_with(60)
+    # Check that clean_scheduler_memory was called for each client
+    assert mock_clean.call_count == 2
+
+def test_clean_scheduler_memory_for_all_clients_with_error(mocker) -> None:
+    """Test cleaning scheduler memory handles errors."""
+    mock_logger = mocker.patch("cads_broker.dask_utils.logger")
+    mock_sleep = mocker.patch("time.sleep")
+    mock_clean = mocker.patch("cads_broker.dask_utils.clean_scheduler_memory")
+
+    mock_client = Mock(spec=Client)
+    mock_clean.side_effect = Exception("Cleaning error")
+
+    schedulers = dask_utils.Schedulers()
+    schedulers.add_client("client_1", mock_client)
+
+    # Simulate the function running and then stopping after the first iteration
+    mock_sleep.side_effect = [None, KeyboardInterrupt()]
+
+    with pytest.raises(KeyboardInterrupt):
+        dask_utils.clean_scheduler_memory_for_all_clients(schedulers, timeout_seconds=60)
+
+    # Check that error logging was called
+    mock_logger.error.assert_called()

--- a/tests/test_04_dask_utils.py
+++ b/tests/test_04_dask_utils.py
@@ -19,6 +19,7 @@ def test_add_client() -> None:
     retrieved_client = schedulers.get_client("client_1")
     assert retrieved_client is mock_client
 
+
 def test_pop_client() -> None:
     """Test popping a client from the schedulers dict."""
     schedulers = dask_utils.Schedulers()
@@ -30,6 +31,7 @@ def test_pop_client() -> None:
     assert popped_client is mock_client
     assert schedulers.get_client("client_1") is None
 
+
 def test_pop_client_not_found() -> None:
     """Test popping a non-existent client returns None."""
     schedulers = dask_utils.Schedulers()
@@ -37,6 +39,7 @@ def test_pop_client_not_found() -> None:
     popped_client = schedulers.pop_client("non_existent")
 
     assert popped_client is None
+
 
 def test_get_client() -> None:
     """Test getting a client from the schedulers dict."""
@@ -48,6 +51,7 @@ def test_get_client() -> None:
 
     assert retrieved_client is mock_client
 
+
 def test_get_client_not_found() -> None:
     """Test getting a non-existent client returns None."""
     schedulers = dask_utils.Schedulers()
@@ -55,6 +59,7 @@ def test_get_client_not_found() -> None:
     retrieved_client = schedulers.get_client("non_existent")
 
     assert retrieved_client is None
+
 
 def test_get_clients_list() -> None:
     """Test getting all clients as a list."""
@@ -70,6 +75,7 @@ def test_get_clients_list() -> None:
     assert mock_client_1 in clients
     assert mock_client_2 in clients
 
+
 def test_get_clients_addresses() -> None:
     """Test getting all client addresses (keys)."""
     schedulers = dask_utils.Schedulers()
@@ -84,6 +90,7 @@ def test_get_clients_addresses() -> None:
     assert "client_1" in addresses
     assert "client_2" in addresses
 
+
 def test_get_clients_items() -> None:
     """Test getting all client items."""
     schedulers = dask_utils.Schedulers()
@@ -97,6 +104,7 @@ def test_get_clients_items() -> None:
     assert len(items) == 2
     assert ("client_1", mock_client_1) in items
     assert ("client_2", mock_client_2) in items
+
 
 def test_thread_safety() -> None:
     """Test thread safety of Schedulers class."""
@@ -144,6 +152,7 @@ def test_get_number_of_workers_all_running() -> None:
 
     assert result == 3
 
+
 def test_get_number_of_workers_mixed_statuses() -> None:
     """Test getting number of workers with mixed statuses."""
     mock_client = Mock(spec=Client)
@@ -163,6 +172,7 @@ def test_get_number_of_workers_mixed_statuses() -> None:
 
     assert result == 2
 
+
 def test_get_number_of_workers_no_workers() -> None:
     """Test getting number of workers when no workers are available."""
     mock_client = Mock(spec=Client)
@@ -174,6 +184,7 @@ def test_get_number_of_workers_no_workers() -> None:
     result = dask_utils.get_number_of_workers(mock_client)
 
     assert result == 0
+
 
 def test_get_number_of_workers_no_status() -> None:
     """Test getting number of workers when status is missing."""
@@ -218,6 +229,7 @@ def test_get_total_number_of_workers() -> None:
 
     assert result == 3
 
+
 def test_get_total_number_of_workers_empty_list() -> None:
     """Test getting total number of workers with no clients."""
     # Clear cache before test
@@ -240,6 +252,7 @@ def test_create_dask_client_success() -> None:
             "tcp://scheduler:8786", heartbeat_interval=1000
         )
         assert result is mock_client_instance
+
 
 def test_create_dask_client_oserror(mocker) -> None:
     """Test create_dask_client logs error on OSError."""
@@ -278,6 +291,7 @@ def test_get_workers_resources() -> None:
     assert "memory" in result
     assert len(result) == 3
 
+
 def test_get_workers_resources_no_workers() -> None:
     """Test getting workers resources when no workers are available."""
     mock_client = Mock(spec=Client)
@@ -289,6 +303,7 @@ def test_get_workers_resources_no_workers() -> None:
     result = dask_utils.get_workers_resources(mock_client)
 
     assert result == []
+
 
 def test_get_workers_resources_no_resources() -> None:
     """Test getting workers resources when workers have no resources."""
@@ -325,6 +340,7 @@ def test_get_tasks_from_scheduler_success() -> None:
 
     assert result == expected_tasks
 
+
 def test_get_tasks_from_scheduler_commclosed_error(mocker) -> None:
     """Test get_tasks_from_scheduler handles CommClosedError."""
     mock_logger = mocker.patch("cads_broker.dask_utils.logger")
@@ -342,6 +358,7 @@ def test_get_tasks_from_scheduler_commclosed_error(mocker) -> None:
 
     assert result == {}
     mock_logger.error.assert_called_once()
+
 
 def test_get_tasks_from_scheduler_oserror(mocker) -> None:
     """Test get_tasks_from_scheduler handles OSError."""
@@ -367,13 +384,12 @@ def test_kill_job_on_worker_no_client(mocker) -> None:
     # Should not raise any error
     dask_utils.kill_job_on_worker(None, "request_123", mock_session)
 
+
 def test_kill_job_on_worker_success(mocker) -> None:
     """Test successfully killing a job on worker."""
     mock_logger = mocker.patch("cads_broker.dask_utils.logger")
     mock_session = Mock()
-    mock_database_get_worker_pid = mocker.patch(
-        "cads_broker.database.get_worker_pid"
-    )
+    mock_database_get_worker_pid = mocker.patch("cads_broker.database.get_worker_pid")
     mock_client = Mock(spec=Client)
 
     mock_database_get_worker_pid.return_value = [
@@ -386,13 +402,12 @@ def test_kill_job_on_worker_success(mocker) -> None:
     assert mock_client.run.call_count == 2
     mock_logger.info.assert_called()
 
+
 def test_kill_job_on_worker_keyerror(mocker) -> None:
     """Test kill_job_on_worker handles KeyError."""
     mock_logger = mocker.patch("cads_broker.dask_utils.logger")
     mock_session = Mock()
-    mock_database_get_worker_pid = mocker.patch(
-        "cads_broker.database.get_worker_pid"
-    )
+    mock_database_get_worker_pid = mocker.patch("cads_broker.database.get_worker_pid")
     mock_client = Mock(spec=Client)
 
     mock_database_get_worker_pid.return_value = [
@@ -404,13 +419,12 @@ def test_kill_job_on_worker_keyerror(mocker) -> None:
 
     mock_logger.warning.assert_called()
 
+
 def test_kill_job_on_worker_process_lookup_error(mocker) -> None:
     """Test kill_job_on_worker handles ProcessLookupError."""
     mock_logger = mocker.patch("cads_broker.dask_utils.logger")
     mock_session = Mock()
-    mock_database_get_worker_pid = mocker.patch(
-        "cads_broker.database.get_worker_pid"
-    )
+    mock_database_get_worker_pid = mocker.patch("cads_broker.database.get_worker_pid")
     mock_client = Mock(spec=Client)
 
     mock_database_get_worker_pid.return_value = [
@@ -434,6 +448,7 @@ def test_cancel_jobs_on_scheduler_success() -> None:
     call_kwargs = mock_client.run_on_scheduler.call_args[1]
     assert call_kwargs["job_ids"] == job_ids
 
+
 def test_cancel_jobs_on_scheduler_commclosed_error(mocker) -> None:
     """Test cancel_jobs_on_scheduler handles CommClosedError."""
     mock_logger = mocker.patch("cads_broker.dask_utils.logger")
@@ -448,6 +463,7 @@ def test_cancel_jobs_on_scheduler_commclosed_error(mocker) -> None:
 
     mock_logger.error.assert_called_once()
 
+
 def test_cancel_jobs_on_scheduler_oserror(mocker) -> None:
     """Test cancel_jobs_on_scheduler handles OSError."""
     mock_logger = mocker.patch("cads_broker.dask_utils.logger")
@@ -459,6 +475,7 @@ def test_cancel_jobs_on_scheduler_oserror(mocker) -> None:
     dask_utils.cancel_jobs_on_scheduler(mock_client, job_ids)
 
     mock_logger.error.assert_called_once()
+
 
 def test_cancel_jobs_on_scheduler_attribute_error(mocker) -> None:
     """Test cancel_jobs_on_scheduler handles AttributeError."""
@@ -499,12 +516,15 @@ def test_clean_scheduler_memory_for_all_clients(mocker) -> None:
     mock_sleep.side_effect = [None, KeyboardInterrupt()]
 
     with pytest.raises(KeyboardInterrupt):
-        dask_utils.clean_scheduler_memory_for_all_clients(schedulers, timeout_seconds=60)
+        dask_utils.clean_scheduler_memory_for_all_clients(
+            schedulers, timeout_seconds=60
+        )
 
     # Check that sleep was called with the correct timeout
     mock_sleep.assert_called_with(60)
     # Check that clean_scheduler_memory was called for each client
     assert mock_clean.call_count == 2
+
 
 def test_clean_scheduler_memory_for_all_clients_with_error(mocker) -> None:
     """Test cleaning scheduler memory handles errors."""
@@ -522,7 +542,9 @@ def test_clean_scheduler_memory_for_all_clients_with_error(mocker) -> None:
     mock_sleep.side_effect = [None, KeyboardInterrupt()]
 
     with pytest.raises(KeyboardInterrupt):
-        dask_utils.clean_scheduler_memory_for_all_clients(schedulers, timeout_seconds=60)
+        dask_utils.clean_scheduler_memory_for_all_clients(
+            schedulers, timeout_seconds=60
+        )
 
     # Check that error logging was called
     mock_logger.error.assert_called()

--- a/tests/test_20_dispatcher.py
+++ b/tests/test_20_dispatcher.py
@@ -7,7 +7,7 @@ import distributed
 import pytest_mock
 import sqlalchemy as sa
 
-from cads_broker import Environment, dispatcher
+from cads_broker import Environment, dask_utils, dispatcher
 from cads_broker import database as db
 from cads_broker.qos import QoS, Rule
 
@@ -53,13 +53,15 @@ def test_broker_sync_database(
     qos = QoS.QoS(
         rules=Rule.RuleSet(), environment=environment, rules_hash="", logger=logger
     )
+    schedulers = dask_utils.Schedulers()
+    schedulers.add_client("scheduler-1", CLIENT)
     broker = dispatcher.Broker(
-        schedulers={"scheduler-1": CLIENT},
+        schedulers=schedulers,
+        schedulers_url=["scheduler-1"],
         environment=environment,
         qos=qos,
         session_maker_read=session_obj,
         session_maker_write=session_obj,
-        input_schedulers=["scheduler-1"],
     )
 
     in_futures_request_uid = str(uuid.uuid4())
@@ -99,7 +101,7 @@ def test_broker_sync_database(
         return {in_dask_request_uid: {"state": "...", "exception": None}}
 
     mocker.patch(
-        "cads_broker.dispatcher.get_tasks_from_scheduler",
+        "cads_broker.dask_utils.get_tasks_from_scheduler",
         return_value=mock_get_tasks(),
     )
     broker.futures = {in_futures_request_uid: "..."}


### PR DESCRIPTION
This PR addresses the memory leak in the scheduler through several changes:

* It adopts a new standard for internal job IDs. The new format is `req-<request.request_uid>`, which prevents the scheduler from instantiating a new `TaskState` for each job.
* It eliminates the use of internal Dask events for communication between the broker and workers, opting instead to use the events table in the broker database.
* It introduces a thread that manually cleans the scheduler's memory according to a scheduled rule. This process can be externalized to a dedicated cron job once we begin using Helm in production.

It also includes an optimisation for database usage. It consolidates several consecutive commits into a single commit at the end of the operations.

It depends on https://github.com/ecmwf-projects/cads-worker/pull/67

